### PR TITLE
Add provisioning tools for MCP server

### DIFF
--- a/src/test/tools/createServiceAccount.test.ts
+++ b/src/test/tools/createServiceAccount.test.ts
@@ -1,0 +1,54 @@
+import { createServiceAccount, CreateServiceAccountSchema } from "../../tools/createServiceAccount.js";
+import { resetClient } from "../../admina-api.js";
+
+beforeEach(() => {
+  resetClient();
+});
+
+describe("createServiceAccount", () => {
+  test("should validate required fields", () => {
+    const validInput = {
+      organizationId: 123,
+      workspaceId: 456,
+      data: {
+        email: "test@example.com",
+        displayName: "Test User",
+      },
+    };
+    expect(() => CreateServiceAccountSchema.parse(validInput)).not.toThrow();
+  });
+
+  test("should accept workflow run ID", () => {
+    const input = {
+      organizationId: 123,
+      workspaceId: 456,
+      data: { email: "test@example.com" },
+      workflowRunId: "12345678-1234-1234-1234-123456789012",
+    };
+    const parsed = CreateServiceAccountSchema.parse(input);
+    expect(parsed.workflowRunId).toBe("12345678-1234-1234-1234-123456789012");
+  });
+
+  test("should reject invalid UUID for workflowRunId", () => {
+    const invalidInput = {
+      organizationId: 123,
+      workspaceId: 456,
+      data: { email: "test@example.com" },
+      workflowRunId: "invalid-uuid",
+    };
+    expect(() => CreateServiceAccountSchema.parse(invalidInput)).toThrow();
+  });
+
+  test("should accept array values in data", () => {
+    const input = {
+      organizationId: 123,
+      workspaceId: 456,
+      data: {
+        email: "test@example.com",
+        licenses: ["license1", "license2"],
+        roles: ["admin"],
+      },
+    };
+    expect(() => CreateServiceAccountSchema.parse(input)).not.toThrow();
+  });
+});

--- a/src/test/tools/getProvisioningMeta.test.ts
+++ b/src/test/tools/getProvisioningMeta.test.ts
@@ -1,0 +1,43 @@
+import { getProvisioningMeta, ProvisioningMetaFiltersSchema } from "../../tools/getProvisioningMeta.js";
+import { resetClient } from "../../admina-api.js";
+
+beforeEach(() => {
+  resetClient();
+});
+
+describe("getProvisioningMeta", () => {
+  test("should validate required fields", () => {
+    const validInput = {
+      organizationId: 123,
+      workspaceId: 456,
+    };
+    expect(() => ProvisioningMetaFiltersSchema.parse(validInput)).not.toThrow();
+  });
+
+  test("should use default language", () => {
+    const input = {
+      organizationId: 123,
+      workspaceId: 456,
+    };
+    const parsed = ProvisioningMetaFiltersSchema.parse(input);
+    expect(parsed.lang).toBe("ja");
+  });
+
+  test("should accept explicit language", () => {
+    const input = {
+      organizationId: 123,
+      workspaceId: 456,
+      lang: "en" as const,
+    };
+    const parsed = ProvisioningMetaFiltersSchema.parse(input);
+    expect(parsed.lang).toBe("en");
+  });
+
+  test("should reject invalid organization ID", () => {
+    const invalidInput = {
+      organizationId: "invalid",
+      workspaceId: 456,
+    };
+    expect(() => ProvisioningMetaFiltersSchema.parse(invalidInput)).toThrow();
+  });
+});

--- a/src/tools/createServiceAccount.ts
+++ b/src/tools/createServiceAccount.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { getClient } from "../admina-api.js";
+
+export const CreateServiceAccountSchema = z.object({
+  organizationId: z.number().describe("Organization ID where the workspace belongs"),
+  workspaceId: z.number().describe("Workspace ID to create account in"),
+  data: z.record(z.union([z.string(), z.array(z.string())])).describe("Account data based on provisioning metadata from get_provisioning_meta"),
+  workflowRunId: z.string().uuid().optional().describe("Optional workflow run ID for tracking"),
+  lang: z.enum(["ja", "en"]).default("ja").describe("Language for responses"),
+});
+
+export type CreateServiceAccountRequest = z.infer<typeof CreateServiceAccountSchema>;
+
+export async function createServiceAccount(request: CreateServiceAccountRequest) {
+  const client = getClient();
+  const { organizationId, workspaceId, lang, ...body } = request;
+  
+  return client.makeApiCall(
+    `/organizations/${organizationId}/workspaces/${workspaceId}/accounts`,
+    { lang },
+    "POST",
+    body
+  );
+}

--- a/src/tools/getProvisioningMeta.ts
+++ b/src/tools/getProvisioningMeta.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { getClient } from "../admina-api.js";
+
+export const ProvisioningMetaFiltersSchema = z.object({
+  organizationId: z.number().describe("Organization ID where the workspace belongs"),
+  workspaceId: z.number().describe("Workspace ID to get provisioning metadata for"),
+  lang: z.enum(["ja", "en"]).default("ja").describe("Language for field descriptions"),
+});
+
+export type ProvisioningMetaFilters = z.infer<typeof ProvisioningMetaFiltersSchema>;
+
+export async function getProvisioningMeta(filters: ProvisioningMetaFilters) {
+  const client = getClient();
+  const { organizationId, workspaceId, lang } = filters;
+  
+  return client.makeApiCall(
+    `/organizations/${organizationId}/workspaces/${workspaceId}/provisioning-meta`,
+    { lang }
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,3 +2,5 @@ export * from "./getDevices.js";
 export * from "./getIdentities.js";
 export * from "./getServices.js";
 export * from "./getServiceAccounts.js";
+export * from "./getProvisioningMeta.js";
+export * from "./createServiceAccount.js";


### PR DESCRIPTION
## Summary
- Adds `get_provisioning_meta` tool to fetch workspace provisioning metadata 
- Adds `create_service_account` tool to provision new service accounts
- Updates API client to support POST requests with body data
- Includes comprehensive test coverage for new provisioning functionality

## Implementation Details
- Tools follow clear 2-step workflow: get metadata first, then create account
- Enhanced tool descriptions show dependency relationships for better MCP client understanding
- Supports all provisioning parameters from vulcan API including dynamic data fields
- Maintains existing API patterns and error handling

## Test plan
- [x] Unit tests pass for schema validation
- [x] TypeScript compilation succeeds
- [ ] Integration testing with actual API endpoints
- [ ] End-to-end provisioning workflow testing

🤖 Generated with [Claude Code](https://claude.ai/code)