### PR TITLE
feature: add MCP request source header for API calls

### DIFF
--- a/src/admina-api.ts
+++ b/src/admina-api.ts
@@ -2,6 +2,11 @@ import { URLSearchParams } from "node:url";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
 import { createAdminaError } from "./common/errors.js";
 
+// Header sent on every request so the API can distinguish MCP (AI) calls from other clients for usage tracking
+export const MCP_USAGE_TRACKING_HEADERS = {
+  "X-Request-Source": "mcp",
+} as const;
+
 function getConfig(): { apiKey: string; organizationId: string } {
   if (!process.env.ADMINA_API_KEY || !process.env.ADMINA_ORGANIZATION_ID) {
     throw new Error("ADMINA_API_KEY and ADMINA_ORGANIZATION_ID must be set");
@@ -36,6 +41,7 @@ export class AdminaApiClient {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
+          ...MCP_USAGE_TRACKING_HEADERS,
         },
         ...config,
       });
@@ -65,6 +71,7 @@ export class AdminaApiClient {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
+          ...MCP_USAGE_TRACKING_HEADERS,
         },
         ...config,
       });
@@ -91,6 +98,7 @@ export class AdminaApiClient {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
+          ...MCP_USAGE_TRACKING_HEADERS,
         },
         ...config,
       });
@@ -117,6 +125,7 @@ export class AdminaApiClient {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
+          ...MCP_USAGE_TRACKING_HEADERS,
         },
         ...config,
       });
@@ -139,6 +148,7 @@ export class AdminaApiClient {
         headers: {
           Authorization: `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
+          ...MCP_USAGE_TRACKING_HEADERS,
         },
         ...config,
       });

--- a/src/test/tools/getOrganizationInfo.test.ts
+++ b/src/test/tools/getOrganizationInfo.test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { resetClient } from "../../admina-api.js";
+import { MCP_USAGE_TRACKING_HEADERS, resetClient } from "../../admina-api.js";
 import { getOrganizationInfo } from "../../tools/getOrganizationInfo.js";
 
 // Define the shape of our mock response
@@ -41,6 +41,8 @@ describe("getOrganizationInfo", () => {
     expect(mockedAxios.get).toHaveBeenCalled();
     const callUrl = mockedAxios.get.mock.calls[0][0];
     expect(callUrl).toContain("/organizations/");
+    const callConfig = mockedAxios.get.mock.calls[0][1];
+    expect(callConfig?.headers).toMatchObject(MCP_USAGE_TRACKING_HEADERS);
 
     expect(result).toEqual(mockOrganizationResponse);
   });


### PR DESCRIPTION
# Description

## Changes

### src/admina-api.ts
- Added `MCP_USAGE_TRACKING_HEADERS`:
  ```ts
  { "X-Request-Source": "mcp" }
  ```
- Applied `MCP_USAGE_TRACKING_HEADERS` to all HTTP methods:
  - GET
  - POST
  - PATCH
  - PUT
  - DELETE

### src/test/tools/getOrganizationInfo.test.ts
- Imported `MCP_USAGE_TRACKING_HEADERS`
- Added a test assertion to ensure requests include `MCP_USAGE_TRACKING_HEADERS`

## Motivation

The Admina API is used by both MCP (AI) clients and other clients.  
To accurately measure and report usage, the backend must distinguish MCP-originated requests from other public API traffic.

This change ensures that every request sent from the MCP server includes:

```ts
X-Request-Source: mcp
```

This allows the backend to identify and track MCP usage separately.

---
# Test Results
### Unit tests
Result: All tests passed
Suites: 27 passed
Tests: 105 passed
Relevant: getOrganizationInfo.test.ts passes, including the new assertion that the X-Request-Source: mcp header is sent.

### MCP integration test
Tool: get_organization_info (MCP)
Result: Succeeded
Response: Organization data returned as expected:
name: i.moneyforward.com
status: active
uniqueName: test-cs3
Other fields present as expected

---

# Linked PR / Issues

Fixes #17

---

# Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chore (routine task, maintenance, or non-functional change)

---

# Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward-i/admina-mcp-server/blob/main/CONTRIBUTING.md)
- [x] Performed a self-review of my code

---

# References

<!-- List all links to information referenced in creating this PR. -->

🤖 Codes are generated and tests are conducted with [Cursor](https://cursor.com/)