### PR TITLE
feat: add remote HTTP transport for multi-tenant MCP (ADM-763)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ MCP server for the Admina API.
 
 To configure the admina-mcp-server, you will need the `organizationId` and an API key. For more details on obtaining your API key, please refer to the [Getting Started Guide](https://docs.itmc.i.moneyforward.com/reference/getting-started-1#step-1-obtain-your-api-key).
 
-## MCP Client Configuration
-To configure this MCP server, add the following configuration to your mcp settings. 
+The server supports two transports:
+
+- **stdio** (default) — local subprocess, credentials from environment variables. Use this for Claude Desktop, Cursor, and similar clients.
+- **HTTP (Streamable HTTP)** — remote server, credentials per request via headers. Use this for hosted deployments and multi-tenant setups. See [docs/remote-mcp.md](docs/remote-mcp.md) for the full spec.
+
+## MCP Client Configuration (stdio)
+To run the server locally as a subprocess, add the following configuration to your MCP client settings:
 ```
 {
   "mcpServers": {
@@ -67,6 +72,37 @@ To configure this MCP server, add the following configuration to your mcp settin
 ```
 
 For local set up, run `yarn build:dev` and set the path to the root dir.
+
+## MCP Client Configuration (HTTP / Remote)
+
+Start the server in HTTP mode:
+
+```
+admina-mcp-server --http --port 3000
+```
+
+Defaults: bind `127.0.0.1:3000`, path `/mcp`. Override via `--host`, `--port`, or `MCP_HTTP_HOST` / `MCP_HTTP_PORT` env vars.
+
+In HTTP mode the server is stateless: credentials are supplied per request via HTTP headers (`Authorization: Bearer <API_KEY>` and `X-Admina-Organization-Id: <ORG_ID>`). A single instance can serve many tenants.
+
+Client configuration example (exact key names vary by client):
+
+```
+{
+  "mcpServers": {
+    "admina-remote": {
+      "type": "http",
+      "url": "https://your-deployment.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <API Key>",
+        "X-Admina-Organization-Id": "<Organization Id>"
+      }
+    }
+  }
+}
+```
+
+See [docs/remote-mcp.md](docs/remote-mcp.md) for auth details, multi-tenant setup, security notes, and a curl smoke test.
 
 ## Releasing
 ### Preparing a release

--- a/docs/plans/2026-04-23-adm-763-remote-mcp-server.md
+++ b/docs/plans/2026-04-23-adm-763-remote-mcp-server.md
@@ -1,0 +1,356 @@
+# ADM-763 — Remote MCP server for admina-mcp-server
+
+**Ticket:** https://www.notion.so/mfi/Remote-MCP-server-33a9b9c183cb8069aa4cd5e1b8c6545b
+**PDD reference:** https://github.com/moneyforward-i/admina-product-document/discussions/36
+**Branch:** `feat/adm-763-remote-mcp-server`
+**Planner model used:** `anthropic/claude-opus-4-7` (max thinking)
+
+## Context
+
+`admina-mcp-server` is currently a **stdio-only** MCP server distributed as an npm package. End users run it locally (via `npx`) and configure it with `ADMINA_API_KEY` + `ADMINA_ORGANIZATION_ID` environment variables. All ~30 tools hit Admina's REST API at `https://api.itmc.i.moneyforward.com/api/v1`.
+
+The ticket asks to publish a **Remote MCP server** so third-party AI agent developers and in-house builders can connect to Admina over HTTP instead of spawning a local process. This is the first piece of a broader "open platform" strategy (the second piece — Public API — is out of scope for this ticket).
+
+### Requirements from the PDD
+
+In scope:
+
+1. Remote MCP transport (HTTP-based) — users connect their MCP clients over the network.
+2. All existing Admina-Helpdesk tools exposed identically over remote MCP (maximum coverage).
+3. Multi-tenant support — a single deployed instance can serve multiple organizations by accepting credentials per request.
+4. Multi-tenant switching UX on the client side: client registers two server entries (one per tenant); server itself does not multiplex.
+5. Documentation on `docs.itmc` (followed up separately — we ship a `docs/remote-mcp.md` here).
+
+Out of scope:
+
+- MCP for Helpdesk chat sessions (admin-bot interaction)
+- Public REST API (separate ticket)
+- OAuth 2.1 flow — pragmatic bearer-token auth for MVP; can layer OAuth later.
+
+## Current architecture + gaps
+
+```
+src/
+├── index.ts              # Server + Stdio transport, inlined
+├── admina-api.ts         # AdminaApiClient + singleton getClient() reads env vars
+├── common/               # error classes, zod schemas, helpers
+└── tools/                # 30+ tool handlers — each calls getClient() at exec time
+```
+
+Gaps for remote deployment:
+
+1. **`getClient()` singleton reads env vars at first call.** In a multi-tenant HTTP server, one process serves many tenants — a global singleton leaks credentials across requests.
+2. **Server is module-scoped.** Instantiated at import time, connected to stdio. No entry point for HTTP.
+3. **Tools call `getClient()` with no arguments.** Passing credentials through 30 function signatures is invasive; async context is non-invasive.
+4. **No HTTP framework or request auth.**
+5. **No CLI transport selector.** `admina-mcp-server` always runs stdio.
+
+## Design decisions
+
+### 1. Transport: Streamable HTTP, stateless mode
+
+MCP SDK `1.26.0` ships `StreamableHTTPServerTransport` (Node-compatible wrapper around the web-standard transport). The spec defines two modes:
+
+- **Stateful** — server generates a session ID on `initialize`, tracks it across requests.
+- **Stateless** — `sessionIdGenerator: undefined`. Every POST is independent; no server-side session state.
+
+**Chosen: stateless.**
+
+Rationale:
+
+- Multi-tenant remote deployment wants horizontal scalability — any node can serve any request.
+- Credentials come from headers per request, not from an init handshake → no session to maintain.
+- Simpler operationally (no session GC, no reconnection logic).
+
+### 2. Auth: Bearer token + organization ID header
+
+Pragmatic, matches Admina's existing REST API auth, minimal client-side config:
+
+```
+Authorization: Bearer <ADMINA_API_KEY>
+X-Admina-Organization-Id: <ADMINA_ORGANIZATION_ID>
+```
+
+Missing/malformed headers → 401 with a JSON error body `{ error: "unauthorized", message: "..." }`.
+
+OAuth 2.1 (the MCP spec's recommended remote auth) can be layered later by wrapping this transport. Out of scope for this ticket.
+
+### 3. Per-request credentials: AsyncLocalStorage
+
+Introduce `src/context.ts`:
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface Credentials {
+  apiKey: string;
+  organizationId: string;
+}
+
+const store = new AsyncLocalStorage<Credentials>();
+
+export const withCredentials = <T>(creds: Credentials, fn: () => T): T =>
+  store.run(creds, fn);
+
+export const getCurrentCredentials = (): Credentials | undefined => store.getStore();
+```
+
+`admina-api.ts` consults the context first, then falls back to env vars (preserves stdio behavior unchanged):
+
+```ts
+export const getClient = (): AdminaApiClient => {
+  const ctx = getCurrentCredentials();
+  if (ctx) return new AdminaApiClient(ctx.apiKey, ctx.organizationId);
+
+  if (clientInstance) return clientInstance;
+  const { apiKey, organizationId } = getConfigFromEnv();
+  clientInstance = new AdminaApiClient(apiKey, organizationId);
+  return clientInstance;
+};
+```
+
+**Key invariant:** in HTTP mode every request runs inside `withCredentials(...)`, so `getClient()` always returns a fresh, request-scoped client. The env-var singleton path is dead code in HTTP mode.
+
+Trade-offs considered:
+
+- **Pass `client` through every tool function**: 30+ signature changes, touches every tool file. Rejected.
+- **Pass credentials via `AuthInfo.extra`**: MCP SDK exposes `AuthInfo` to handlers only via `extra.authInfo` on request context. Usable but requires threading through request handlers. AsyncLocalStorage is simpler and tools don't need to know about the transport.
+- **Module-level mutable "current credentials"**: race conditions on concurrent requests. Rejected.
+
+### 4. Server factory: one server per HTTP request, shared factory
+
+`createServer()` in `src/server.ts` builds a fresh `Server` instance with all handlers wired. Each POST to `/mcp` creates its own `Server` + `StreamableHTTPServerTransport`, connects them, handles the request, and closes.
+
+Why one-per-request: the stateless mode is designed for this pattern; it avoids any shared state accidentally leaking between tenants. The `Server` object is cheap — just handler registration.
+
+### 5. No new HTTP framework — use Node `http`
+
+The SDK provides `createMcpExpressApp()` but that pulls in `express`. We only need a single POST endpoint; Node built-in `http` + `URL` parsing is 30 LOC and zero new deps.
+
+Only adding `@hono/node-server` which is already a transitive dep of the MCP SDK — the Streamable HTTP transport uses it internally, no action needed on our part.
+
+### 6. CLI: env-var + flag selector
+
+`admina-mcp-server` (no args / env) → stdio, same as today.
+`admina-mcp-server --http [--port N] [--host H]` → HTTP mode.
+`MCP_TRANSPORT=http MCP_HTTP_PORT=3000 admina-mcp-server` → same.
+
+Defaults: `--port 3000`, `--host 127.0.0.1`. Bind to loopback by default for safety; operators deploying remotely explicitly opt into `0.0.0.0` or a public interface.
+
+### 7. Backward compatibility
+
+No public API changes for existing stdio users. The only behavior change in stdio mode is that `getClient()` now does an AsyncLocalStorage lookup that always misses — negligible overhead, no semantic difference.
+
+## Acceptance criteria
+
+Derived from the PDD and the architectural decisions:
+
+1. **AC-1 (stdio backward compat):** `admina-mcp-server` invoked with no arguments and valid env vars connects over stdio and behaves exactly as today. All 30 existing tools succeed unchanged.
+2. **AC-2 (HTTP happy path):** `admina-mcp-server --http` starts an HTTP server. POST `/mcp` with `Content-Type: application/json`, `Accept: application/json, text/event-stream`, `Authorization: Bearer <valid-key>`, `X-Admina-Organization-Id: <valid-id>`, and a well-formed MCP JSON-RPC body returns a 200 with the expected MCP response.
+3. **AC-3 (HTTP list_tools + call_tool):** Over HTTP, `tools/list` returns the same list as stdio; `tools/call` invocations on any existing tool produce equivalent responses (keyed off the AdminaApiClient making real calls — verified via mocked axios in tests).
+4. **AC-4 (missing auth):** POST `/mcp` without `Authorization` header returns 401 with `{ error: "unauthorized", message: "Missing or invalid Authorization header" }`.
+5. **AC-5 (missing org):** POST `/mcp` with a valid `Authorization` but no `X-Admina-Organization-Id` returns 401 with a clear error.
+6. **AC-6 (tenant isolation):** Two concurrent requests with different `(apiKey, orgId)` credentials each see their own credentials inside tool handlers — no cross-contamination. Verified by a test that dispatches two requests with different creds and asserts the outbound axios calls carry the expected `Authorization` and URL `/organizations/<orgId>/...`.
+7. **AC-7 (method enforcement):** Non-POST methods (GET, DELETE) on `/mcp` return 405 (or delegated to the SDK's transport which returns 405/400 as per the MCP spec). POST on any other path returns 404.
+8. **AC-8 (localhost binding default):** By default the server binds to `127.0.0.1`. An operator can opt into `0.0.0.0` via `--host`.
+9. **AC-9 (documentation):** `README.md` describes both stdio and HTTP modes. A new `docs/remote-mcp.md` covers client configuration, headers, auth, and a multi-tenant example.
+10. **AC-10 (no regression):** `yarn test` passes all existing tests; `yarn lint` passes; `yarn build` emits a working `build/index.js`.
+
+## Implementation phases
+
+### Phase 1: AsyncLocalStorage credential context
+
+**Files:**
+
+- `src/context.ts` (new)
+
+**Changes:**
+
+- Define `Credentials` interface (`apiKey`, `organizationId`).
+- Export `credentialStore` (`AsyncLocalStorage<Credentials>`), `withCredentials(creds, fn)`, `getCurrentCredentials()`.
+
+**Tests:** `src/test/context.test.ts` — verify `run` scoping, nested calls, isolation across two `Promise.all` flows.
+
+### Phase 2: Refactor `admina-api.ts` to read credentials from context
+
+**Files:**
+
+- `src/admina-api.ts` (modified)
+
+**Changes:**
+
+- Extract `getConfigFromEnv()` (private) that reads env vars and throws on missing.
+- `getClient()` checks `getCurrentCredentials()` first, constructs and returns a **new** `AdminaApiClient` when context is present (do **not** cache — creds vary per request).
+- Preserve the env-var singleton path for stdio mode (no change in behavior).
+- Keep `resetClient()` for tests.
+
+**Tests:** extend existing admin-api tests (if any) or add `src/test/admina-api.test.ts` verifying:
+
+- With context set → returns client using context creds, does not hit env.
+- Without context, with env vars → returns singleton from env.
+- Without context, without env → throws.
+- Two concurrent `withCredentials` scopes produce isolated clients.
+
+### Phase 3: Extract server factory
+
+**Files:**
+
+- `src/server.ts` (new)
+- `src/index.ts` (refactored)
+
+**Changes:**
+
+- Move `new Server(...)`, `setRequestHandler(ListToolsRequestSchema, ...)`, and `setRequestHandler(CallToolRequestSchema, ...)` from `index.ts` into a `createServer(): Server` factory.
+- `index.ts` becomes a thin entry that picks the transport based on args/env.
+
+**Tests:** none — this phase is a pure refactor validated by AC-1 + existing tool tests.
+
+### Phase 4: Stdio transport module
+
+**Files:**
+
+- `src/transports/stdio.ts` (new)
+
+**Changes:**
+
+- `export const runStdio = async () => { const server = createServer(); await server.connect(new StdioServerTransport()); }`.
+- Replaces the last two lines of the current `index.ts`.
+
+### Phase 5: HTTP transport module
+
+**Files:**
+
+- `src/transports/http.ts` (new)
+
+**Changes:**
+
+- `export interface HttpOptions { port: number; host: string }`.
+- `export const runHttp = async (opts: HttpOptions) => { ... }`:
+  - Creates Node `http.Server`.
+  - Only accepts POST `/mcp`. Other paths → 404. Other methods on `/mcp` are delegated to the MCP SDK transport which handles them per spec.
+  - On POST:
+    1. Extract `Authorization: Bearer <key>` and `X-Admina-Organization-Id: <id>`. Respond 401 on missing/malformed.
+    2. Parse JSON body (stream `req` → Buffer → `JSON.parse`). Respond 400 on parse error.
+    3. `await withCredentials({ apiKey, organizationId }, async () => { ... })`:
+       - Create a fresh `Server` via `createServer()`.
+       - Create `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`.
+       - `await server.connect(transport)`.
+       - `await transport.handleRequest(req, res, parsedBody)`.
+       - `res` close triggers `transport.close()` → `server.close()`.
+  - Logs basic per-request info (method, path, status) on close. Do not log credentials.
+
+**Tests:** `src/test/transports/http.test.ts`:
+
+- AC-4, AC-5: auth rejections.
+- AC-6: two concurrent requests with different creds → axios adapter mock asserts outbound `Authorization` header matches the inbound (two distinct values).
+- AC-2, AC-3: happy-path `tools/list` + `tools/call` (axios mocked to return canned Admina responses).
+
+### Phase 6: CLI + entry point
+
+**Files:**
+
+- `src/index.ts` (finalized)
+
+**Changes:**
+
+- Parse `process.argv` for `--http`, `--port <n>`, `--host <s>`.
+- Fall back to env: `MCP_TRANSPORT=http`, `MCP_HTTP_PORT`, `MCP_HTTP_HOST`.
+- If HTTP mode: `await runHttp({ port, host })`. Else: `await runStdio()`.
+- Preserve shebang `#!/usr/bin/env node`.
+
+**Tests:** argv parsing unit test in `src/test/cli.test.ts` (small — just the parser function).
+
+### Phase 7: Documentation + README
+
+**Files:**
+
+- `README.md` (updated)
+- `docs/remote-mcp.md` (new)
+
+**Changes:**
+
+- README: add "HTTP (Remote) Mode" section near the existing config snippet. Show both modes.
+- `docs/remote-mcp.md`:
+  - Why remote MCP (brief).
+  - How to run (`admina-mcp-server --http --port 3000`).
+  - Required headers with examples.
+  - Error responses (401, 400).
+  - Multi-tenant client config example — two server entries, one per organization.
+  - Security notes: default bind is loopback, use TLS terminator in front for public deployments, credentials live in request headers only.
+
+### Phase 8: Wiring + verification
+
+- `yarn build` — compiles.
+- `yarn test` — existing tests green, new tests green.
+- `yarn lint` — biome green.
+- Local smoke test of HTTP mode with `curl`:
+  ```
+  curl -sS -X POST http://127.0.0.1:3000/mcp \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $ADMINA_API_KEY" \
+    -H "X-Admina-Organization-Id: $ADMINA_ORGANIZATION_ID" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+  ```
+
+## E2E scenarios (documented; automated via unit/integration tests)
+
+1. **Scenario — stdio-mode, `tools/list`:** Spawn `build/index.js` with env vars set, write a JSON-RPC `tools/list` request to stdin, read stdout, verify `result.tools` contains 30+ entries.
+2. **Scenario — HTTP-mode, `initialize` + `tools/list` + `tools/call`:** Start `runHttp({ port: 0, host: '127.0.0.1' })` in the test, POST three requests, verify each returns a valid MCP response.
+3. **Scenario — HTTP-mode missing auth:** POST without `Authorization` → 401 body contains `error: "unauthorized"`.
+4. **Scenario — HTTP-mode tenant isolation:** Fire two `tools/call` invocations (both `get_organization_info`) with different `(apiKey, orgId)` pairs concurrently. Mock axios to capture the outbound requests. Assert each outbound request carries the credentials of the inbound request that spawned it — never swapped.
+5. **Scenario — HTTP-mode invalid JSON body:** POST with body `not-json` → 400.
+6. **Scenario — HTTP-mode non-POST method:** GET `/mcp` returns 405 (delegated to transport per MCP spec).
+7. **Scenario — HTTP-mode unknown path:** POST `/health` returns 404.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| AsyncLocalStorage overhead on hot path | Negligible at the QPS this server sees (Admina API itself is the bottleneck). Not optimizing. |
+| StreamableHTTPServerTransport version mismatch | SDK is `^1.10.1` in package.json but installed is `1.26.0` — transport API has been stable since 1.10. Verified by reading the .d.ts. |
+| Tenant credential leak through logs | Never log `Authorization` header or request body. Logs only capture method/path/status. |
+| Rate-limit abuse on public endpoint | Out of scope — deployed operators are expected to put a rate-limiter / API gateway in front. Documented in `docs/remote-mcp.md`. |
+| Existing stdio users break | Env-var fallback path in `getClient()` preserves current semantics exactly. Covered by AC-1 + existing tool tests (already passing on main). |
+| Binding `0.0.0.0` by default would be risky | Default to `127.0.0.1`; operator must explicitly set `--host 0.0.0.0`. |
+
+## File inventory (deltas)
+
+| File | Change |
+|---|---|
+| `src/context.ts` | **new** — AsyncLocalStorage credential context |
+| `src/admina-api.ts` | modified — `getClient()` reads context first, falls back to env |
+| `src/server.ts` | **new** — `createServer()` factory extracted from `index.ts` |
+| `src/transports/stdio.ts` | **new** — `runStdio()` |
+| `src/transports/http.ts` | **new** — `runHttp(opts)` with auth + stateless transport |
+| `src/index.ts` | refactored — CLI flag/env parse, delegates to transport |
+| `src/test/context.test.ts` | **new** |
+| `src/test/admina-api.test.ts` | **new** |
+| `src/test/transports/http.test.ts` | **new** |
+| `src/test/cli.test.ts` | **new** |
+| `README.md` | updated — HTTP mode section |
+| `docs/remote-mcp.md` | **new** |
+
+No new runtime dependencies. No dev-dep changes unless tests need supertest-style helpers (use `node:http.request` directly to avoid the dep).
+
+## Out of scope / follow-ups
+
+- OAuth 2.1 flow per MCP spec.
+- Session-stateful HTTP (SSE stream reuse across requests) — YAGNI for stateless multi-tenant.
+- Rate limiting, per-tenant quotas — infrastructure concern.
+- OpenTelemetry / structured logs — separate infra ticket.
+- Publishing docs to `docs.itmc` — content delivery handled outside this repo.
+- Public REST API (the other half of GitHub discussion #36).
+
+## Commit plan
+
+One logical commit per phase:
+
+1. `feat(context): add AsyncLocalStorage credential context`
+2. `refactor(admina-api): read credentials from context with env fallback`
+3. `refactor(server): extract createServer() factory`
+4. `refactor(transports): split stdio into its own module`
+5. `feat(transports): add stateless HTTP transport with bearer auth`
+6. `feat(cli): select transport via --http flag or MCP_TRANSPORT env`
+7. `test: cover context, admina-api, cli, and http transport`
+8. `docs: document remote MCP mode and multi-tenant client config`

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -58,13 +58,13 @@ See the [Admina API docs](https://docs.itmc.i.moneyforward.com/reference/getting
 
 ## Endpoint
 
-| Method | Path | Purpose |
+| Method | Path | Response |
 |---|---|---|
-| `POST` | `/mcp` | Send an MCP JSON-RPC message (initialize, tools/list, tools/call, …) |
-| `GET` | `/mcp` | Open a streaming response (reserved; not needed by most clients) |
-| `DELETE` | `/mcp` | Reserved by the MCP spec for session teardown. Not meaningful in the stateless server — safe to call and ignore the response. |
+| `POST` | `/mcp` | MCP JSON-RPC response (initialize, tools/list, tools/call, …) |
+| any other method | `/mcp` | `405 Method Not Allowed` with `Allow: POST` |
+| any method | anywhere else | `404 Not Found` |
 
-The server is **stateless** — every request stands alone and includes its own credentials, so there is no MCP session to tear down between requests.
+The server runs in **stateless** mode — every request stands alone and carries its own credentials. There is no MCP session, so the spec's GET (long-lived SSE stream) and DELETE (session teardown) endpoints have nothing to operate on and return 405.
 
 ## Client configuration
 
@@ -129,11 +129,14 @@ curl -sS -X POST http://127.0.0.1:3000/mcp \
 
 ## Security notes
 
-- **Default bind is `127.0.0.1`** — the server is only reachable from the local host. To expose it on a network interface you must pass `--host 0.0.0.0` (or a specific IP) explicitly.
+- **Default bind is `127.0.0.1`** — the server is only reachable from the local host. To expose it on a network interface pass `--host 0.0.0.0` (or a specific IP) explicitly.
+- **DNS rebinding protection is on by default for loopback binds.** When `--host` is `127.0.0.1`, `localhost`, or `::1`, incoming requests must carry a `Host` header matching one of `127.0.0.1:<port>`, `localhost:<port>`, or `[::1]:<port>`; other hosts return `403 forbidden_host`. For non-loopback binds you are responsible for configuring DNS-rebinding protection upstream (reverse proxy, API gateway, `allowedHosts` option if embedding `runHttp` programmatically).
+- **Organization ID is shape-validated.** The server rejects `X-Admina-Organization-Id` values that do not match `^[A-Za-z0-9_-]{1,64}$` with `400 invalid_organization_id`. This prevents path-injection via the URL interpolated into outbound Admina API calls.
 - **Always put TLS in front of a public deployment.** The bearer token and organization ID travel in request headers; they are secrets.
-- **The server itself does no rate-limiting.** For public deployments, put an API gateway or reverse proxy (Cloudflare, nginx, AWS API Gateway, etc.) in front with appropriate rate limits.
+- **The server does no rate-limiting.** For public deployments, put an API gateway or reverse proxy (Cloudflare, nginx, AWS API Gateway, etc.) in front with appropriate rate limits.
 - **Never log credentials.** The server deliberately does not emit request headers or bodies — keep that discipline in any middleware you add.
 - **Bearer tokens are per-request.** There is no session; compromising a single request does not grant forward access. Rotate keys in Admina if you suspect a leak.
+- **Request body size is capped at 1 MiB.** Oversized payloads return `413 payload_too_large`.
 
 ## Troubleshooting
 
@@ -141,6 +144,10 @@ curl -sS -X POST http://127.0.0.1:3000/mcp \
 |---|---|---|
 | 401 "Missing Authorization header" | No `Authorization` header sent | Add `Authorization: Bearer <ADMINA_API_KEY>` |
 | 401 "Missing X-Admina-Organization-Id header" | Organization ID header absent | Add `X-Admina-Organization-Id: <ORG_ID>` |
+| 400 "invalid_organization_id" | Org ID header fails shape check | Must match `/^[A-Za-z0-9_-]{1,64}$/` |
 | 400 "Request body must be valid JSON." | Body is not JSON | Ensure a well-formed JSON-RPC body |
+| 403 "forbidden_host" | DNS-rebinding check rejected `Host` header | For loopback binds, use `127.0.0.1:<port>`, `localhost:<port>`, or `[::1]:<port>`. For non-loopback binds, configure `allowedHosts`. |
 | 404 "Unknown path" | Requested path other than `/mcp` | Use `POST /mcp` |
+| 405 "method_not_allowed" | Non-POST method on `/mcp` | Use POST (stateless mode) |
+| 413 "payload_too_large" | Body exceeds 1 MiB | Split work into smaller requests |
 | 500 Internal from a tool call | Admina API returned an error; the MCP response wraps it | Check tool response body — `isError: true` with the Admina message |

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -1,0 +1,146 @@
+# Remote MCP server
+
+`admina-mcp-server` ships two transports:
+
+- **stdio** (default) — the traditional local MCP setup. Clients (Claude Desktop, Cursor, VS Code, etc.) spawn the binary as a subprocess and talk to it over stdin/stdout.
+- **HTTP (Streamable HTTP)** — the server listens on a TCP port and accepts MCP requests over HTTP. This is the mode to use when you want to run one shared server that multiple users or tenants connect to remotely.
+
+## When to use HTTP mode
+
+Pick HTTP mode when:
+
+- You want to host a single, shared Admina MCP endpoint instead of having every user install the binary locally.
+- Your clients live in environments that cannot spawn local processes (browser-based agents, hosted IDEs, serverless frameworks).
+- You want to serve multiple Admina organizations from the same instance.
+
+Otherwise, stick with stdio — it is simpler, secret-free for the operator, and still the default.
+
+## Running in HTTP mode
+
+```
+# CLI flags
+admina-mcp-server --http --port 3000 --host 127.0.0.1
+
+# Environment
+MCP_TRANSPORT=http MCP_HTTP_PORT=3000 MCP_HTTP_HOST=127.0.0.1 admina-mcp-server
+```
+
+Defaults when `--http` is set: `--port 3000`, `--host 127.0.0.1`.
+
+Starting the server in HTTP mode does **not** read `ADMINA_API_KEY` or `ADMINA_ORGANIZATION_ID` — those credentials are supplied by each incoming request. A single deployed instance can serve any number of tenants.
+
+On startup it logs:
+
+```
+[admina-mcp-server] listening on http://127.0.0.1:3000/mcp
+```
+
+## Authentication
+
+Every HTTP request must include:
+
+| Header | Required | Notes |
+|---|---|---|
+| `Authorization: Bearer <ADMINA_API_KEY>` | yes | Standard Admina API key |
+| `X-Admina-Organization-Id: <ORGANIZATION_ID>` | yes | Admina organization the request is scoped to |
+| `Content-Type: application/json` | yes (POST) | Required by the MCP Streamable HTTP spec |
+| `Accept: application/json, text/event-stream` | recommended | Required by the MCP Streamable HTTP spec |
+
+A missing or malformed `Authorization` header returns `401 Unauthorized`:
+
+```json
+{ "error": "unauthorized", "message": "Missing Authorization header. ..." }
+```
+
+A missing `X-Admina-Organization-Id` header returns the same shape.
+
+See the [Admina API docs](https://docs.itmc.i.moneyforward.com/reference/getting-started-1#step-1-obtain-your-api-key) for how to obtain an API key.
+
+## Endpoint
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/mcp` | Send an MCP JSON-RPC message (initialize, tools/list, tools/call, …) |
+| `GET` | `/mcp` | Open a streaming response (reserved; not needed by most clients) |
+| `DELETE` | `/mcp` | Reserved by the MCP spec for session teardown. Not meaningful in the stateless server — safe to call and ignore the response. |
+
+The server is **stateless** — every request stands alone and includes its own credentials, so there is no MCP session to tear down between requests.
+
+## Client configuration
+
+### Claude Desktop / Cursor / VS Code — remote MCP
+
+```json
+{
+  "mcpServers": {
+    "admina-production": {
+      "type": "http",
+      "url": "https://your-deployment.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <ADMINA_API_KEY>",
+        "X-Admina-Organization-Id": "<ORG_ID>"
+      }
+    }
+  }
+}
+```
+
+The exact key names (`type`, `url`, `headers`) vary slightly between clients — consult your client's remote MCP documentation.
+
+### Multi-tenant client setup
+
+`admina-mcp-server` does not multiplex tenants on a single connection. To work across multiple Admina organizations in one chat, register one MCP server entry per tenant:
+
+```json
+{
+  "mcpServers": {
+    "admina-tenant-a": {
+      "type": "http",
+      "url": "https://your-deployment.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <API_KEY_A>",
+        "X-Admina-Organization-Id": "<ORG_A>"
+      }
+    },
+    "admina-tenant-b": {
+      "type": "http",
+      "url": "https://your-deployment.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <API_KEY_B>",
+        "X-Admina-Organization-Id": "<ORG_B>"
+      }
+    }
+  }
+}
+```
+
+The agent can then ask the user which tenant to work in and call the corresponding server.
+
+## Smoke test
+
+```bash
+curl -sS -X POST http://127.0.0.1:3000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $ADMINA_API_KEY" \
+  -H "X-Admina-Organization-Id: $ADMINA_ORGANIZATION_ID" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+```
+
+## Security notes
+
+- **Default bind is `127.0.0.1`** — the server is only reachable from the local host. To expose it on a network interface you must pass `--host 0.0.0.0` (or a specific IP) explicitly.
+- **Always put TLS in front of a public deployment.** The bearer token and organization ID travel in request headers; they are secrets.
+- **The server itself does no rate-limiting.** For public deployments, put an API gateway or reverse proxy (Cloudflare, nginx, AWS API Gateway, etc.) in front with appropriate rate limits.
+- **Never log credentials.** The server deliberately does not emit request headers or bodies — keep that discipline in any middleware you add.
+- **Bearer tokens are per-request.** There is no session; compromising a single request does not grant forward access. Rotate keys in Admina if you suspect a leak.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 401 "Missing Authorization header" | No `Authorization` header sent | Add `Authorization: Bearer <ADMINA_API_KEY>` |
+| 401 "Missing X-Admina-Organization-Id header" | Organization ID header absent | Add `X-Admina-Organization-Id: <ORG_ID>` |
+| 400 "Request body must be valid JSON." | Body is not JSON | Ensure a well-formed JSON-RPC body |
+| 404 "Unknown path" | Requested path other than `/mcp` | Use `POST /mcp` |
+| 500 Internal from a tool call | Admina API returned an error; the MCP response wraps it | Check tool response body — `isError: true` with the Admina message |

--- a/src/admina-api.ts
+++ b/src/admina-api.ts
@@ -1,13 +1,14 @@
 import { URLSearchParams } from "node:url";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
 import { createAdminaError } from "./common/errors.js";
+import { getCurrentCredentials } from "./context.js";
 
 // Header sent on every request so the API can distinguish MCP (AI) calls from other clients for usage tracking
 export const MCP_USAGE_TRACKING_HEADERS = {
   "X-Request-Source": "mcp",
 } as const;
 
-function getConfig(): { apiKey: string; organizationId: string } {
+function getConfigFromEnv(): { apiKey: string; organizationId: string } {
   if (!process.env.ADMINA_API_KEY || !process.env.ADMINA_ORGANIZATION_ID) {
     throw new Error("ADMINA_API_KEY and ADMINA_ORGANIZATION_ID must be set");
   }
@@ -165,9 +166,24 @@ export class AdminaApiClient {
 
 let clientInstance: AdminaApiClient | null = null;
 
+/**
+ * Returns an AdminaApiClient for the current request.
+ *
+ * Resolution order:
+ *   1. If running inside a `withCredentials(...)` scope (remote HTTP mode),
+ *      returns a fresh client bound to those credentials. Never cached — two
+ *      concurrent HTTP requests with different tenants must see isolated clients.
+ *   2. Otherwise (stdio mode), returns a process-wide singleton built from
+ *      `ADMINA_API_KEY` + `ADMINA_ORGANIZATION_ID` env vars. Throws if unset.
+ */
 export function getClient(): AdminaApiClient {
+  const ctx = getCurrentCredentials();
+  if (ctx) {
+    return new AdminaApiClient(ctx.apiKey, ctx.organizationId);
+  }
+
   if (!clientInstance) {
-    const config = getConfig();
+    const config = getConfigFromEnv();
     clientInstance = new AdminaApiClient(config.apiKey, config.organizationId);
   }
 
@@ -175,7 +191,7 @@ export function getClient(): AdminaApiClient {
 }
 
 /**
- * Resets the client instance. Useful for testing or reconfiguration.
+ * Resets the env-backed singleton. Useful for tests.
  */
 export function resetClient(): void {
   clientInstance = null;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface Credentials {
+  apiKey: string;
+  organizationId: string;
+}
+
+const credentialStore = new AsyncLocalStorage<Credentials>();
+
+/**
+ * Runs `fn` with `credentials` attached to the current async context.
+ * Downstream calls to `getCurrentCredentials()` inside `fn` (and any async
+ * work it awaits) resolve to the provided credentials.
+ *
+ * Used by the HTTP transport to scope credentials to a single request.
+ */
+export function withCredentials<T>(credentials: Credentials, fn: () => T): T {
+  return credentialStore.run(credentials, fn);
+}
+
+/**
+ * Returns the credentials bound to the current async context, or `undefined`
+ * if none were set. Callers fall back to environment variables when this is
+ * `undefined` (stdio mode).
+ */
+export function getCurrentCredentials(): Credentials | undefined {
+  return credentialStore.getStore();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,393 +1,69 @@
 #!/usr/bin/env node
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { formatAdminaError, isAdminaError } from "./common/errors.js";
-import { CreateIdentityCustomFieldSchema, createIdentityCustomField } from "./tools/createIdentityCustomField.js";
-import { DeleteIdentityCustomFieldSchema, deleteIdentityCustomField } from "./tools/deleteIdentityCustomField.js";
-import { IdentityConfigFiltersSchema, getIdentityConfig } from "./tools/getIdentityConfig.js";
-import { IdentityCustomFieldsFiltersSchema, getIdentityCustomFields } from "./tools/getIdentityCustomField.js";
-import {
-  ArchiveIdentitySchema,
-  BulkUpdateIdentitiesSchema,
-  CheckIdentityManagementTypeSchema,
-  CreateDeviceCustomFieldSchema,
-  CreateDeviceSchema,
-  CreateIdentitySchema,
-  DeleteDeviceCustomFieldSchema,
-  DeleteIdentitySchema,
-  DeviceCustomFieldsSchema,
-  DeviceFiltersSchema,
-  GetIdentitiesStatsSchema,
-  GetIdentityFieldConfigurationSchema,
-  GetIdentityHistorySchema,
-  GetIdentitySchema,
-  IdentityFiltersSchema,
-  MergeIdentitiesSchema,
-  OrganizationInfoSchema,
-  PeopleAccountsFiltersSchema,
-  ServiceAccountFiltersSchema,
-  ServiceFiltersSchema,
-  UnmergeIdentitiesSchema,
-  UnregisterIdentitySchema,
-  UpdateDeviceCustomFieldSchema,
-  UpdateDeviceMetaSchema,
-  UpdateDeviceSchema,
-  UpdateIdentitySchema,
-  archiveIdentity,
-  bulkUpdateIdentities,
-  checkIdentityManagementType,
-  createDevice,
-  createDeviceCustomField,
-  createIdentity,
-  deleteDeviceCustomField,
-  deleteIdentity,
-  getDeviceCustomFields,
-  getDevices,
-  getIdentities,
-  getIdentitiesStats,
-  getIdentity,
-  getIdentityFieldConfiguration,
-  getIdentityHistory,
-  getOrganizationInfo,
-  getPeopleAccounts,
-  getServiceAccounts,
-  getServices,
-  mergeIdentities,
-  unmergeIdentities,
-  unregisterIdentity,
-  updateDevice,
-  updateDeviceCustomField,
-  updateDeviceMeta,
-  updateIdentity,
-} from "./tools/index.js";
-import { UpdateIdentityCustomFieldSchema, updateIdentityCustomField } from "./tools/updateIdentityCustomField.js";
+import { HttpOptions, runHttp } from "./transports/http.js";
+import { runStdio } from "./transports/stdio.js";
 
-const server = new Server(
-  {
-    name: "admina-mpc",
-    version: "1.0.0",
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
+export interface CliOptions {
+  transport: "stdio" | "http";
+  http: HttpOptions;
+}
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "get_organization_info",
-        description:
-          "Get information about the organization including name, unique name, status, system language, etc.",
-        inputSchema: zodToJsonSchema(OrganizationInfoSchema),
-      },
-      {
-        name: "get_devices",
-        description: `Get a list of devices for an organization using advanced search and filtering.
+export const DEFAULT_HTTP_PORT = 3000;
+export const DEFAULT_HTTP_HOST = "127.0.0.1";
 
-## Key Features
-- Combine query parameters (pagination, sorting) with body parameters (filtering)
-- Support for text search, field-specific filters, and complex queries
-- Pagination with cursor-based navigation
+export function parseCliOptions(argv: string[], env: NodeJS.ProcessEnv): CliOptions {
+  let transport: "stdio" | "http" = env.MCP_TRANSPORT === "http" ? "http" : "stdio";
+  let port = env.MCP_HTTP_PORT ? Number(env.MCP_HTTP_PORT) : DEFAULT_HTTP_PORT;
+  let host = env.MCP_HTTP_HOST ?? DEFAULT_HTTP_HOST;
 
-## Example Usage
-**Find first 5 devices for user with email "someone@gmail.com":**
-- Query: limit=5
-- Body: {"searchTerm": "someone@gmail.com", "searchFields": ["people.primaryEmail"]}
-
-## Pro Tips
-- **1**: Always make sure understand the definition of the fields (preset and custom fields) before using them.
-- **2**: If user search devices by category: pc, phone or other, please use body.type to filter devices by category.
-- **3**: Always to understand what are current sub types of the devices. If the user search information relate to sub types, Please use body.filters.["preset.subtype"] to filter devices by sub types.
-- **4**: We don't really need to use searchFields parameter to the search results in all fields, only use it when the user search information relate to specific fields.
-- **5**: If user want to filter devices by status, please use body.filters.["preset.status"].eq to filter devices by status.
-- **5.1**: Unassigned devices status should be "in_stock" or "decommissioned".
-- **6**: If user want to filter devices by preset fields or custom fields, please check the field.kind first, we only support date, number, dropdown kind of fields.
-- **6.1**: If the field.kind is date, please use body.filters.["preset.field_name"].minDate or body.filters.["custom.attributeCode"].minDate and body.filters.["preset.field_name"].maxDate or body.filters.["custom.attributeCode"].maxDate to filter devices by date range.
-- **6.2**: If the field.kind is number, please use body.filters.["preset.field_name"].minNumber or body.filters.["custom.attributeCode"].minNumber and body.filters.["preset.field_name"].maxNumber or body.filters.["custom.attributeCode"].maxNumber to filter devices by number range.
-- **6.3**: If the preset field field.kind is dropdown, please use body.filters.["preset.field_name"].eq or body.filters.["custom.attributeCode"].eq to filter devices by dropdown value.
-- **7**: Combine multiple filters examples: {"preset.status":{"eq":"active"},"preset.subtype":{"eq":"desktop_pc"},"custom.custom_xxx":{"eq":"1"},"custom.dt_13":{"minDate":"2025-12-23","maxDate":"2025-12-25"},"custom.drp_4":{"eq":"1"}}`,
-        inputSchema: zodToJsonSchema(DeviceFiltersSchema),
-      },
-      {
-        name: "create_device",
-        description:
-          "Create a new device for an organization. Requires device type (subtype), asset number, and model name. Can include optional preset fields and custom fields.",
-        inputSchema: zodToJsonSchema(CreateDeviceSchema),
-      },
-      {
-        name: "update_device",
-        description:
-          "Update an existing device's information. Can update preset fields, custom fields, and device properties. Note: fields.preset.asset_number, fields.preset.subtype, fields.preset.model_name are always required.",
-        inputSchema: zodToJsonSchema(UpdateDeviceSchema),
-      },
-      {
-        name: "update_device_meta",
-        description:
-          "Update device's meta information including assignment info (peopleId, status, dates) and location. Use this to assign/unassign devices to people. When unassigned, status should be 'in_stock' or 'decommissioned'. When assigned without status, defaults to 'active'.",
-        inputSchema: zodToJsonSchema(UpdateDeviceMetaSchema),
-      },
-      {
-        name: "get_device_custom_fields",
-        description:
-          "Get all custom fields configured for an organization's devices. Returns field definitions, types (text, date, number, dropdown), and configurations.",
-        inputSchema: zodToJsonSchema(DeviceCustomFieldsSchema),
-      },
-      {
-        name: "create_device_custom_field",
-        description:
-          "Create a new custom field for organization devices. Defines a new field that can be used across all devices in the organization.",
-        inputSchema: zodToJsonSchema(CreateDeviceCustomFieldSchema),
-      },
-      {
-        name: "update_device_custom_field",
-        description:
-          "Update an existing device custom field configuration. Can modify field name, code, visibility for device types, and dropdown configuration.",
-        inputSchema: zodToJsonSchema(UpdateDeviceCustomFieldSchema),
-      },
-      {
-        name: "delete_device_custom_field",
-        description:
-          "Delete a device custom field configuration. Removes a custom field definition from the organization.",
-        inputSchema: zodToJsonSchema(DeleteDeviceCustomFieldSchema),
-      },
-      {
-        name: "get_identities",
-        description:
-          "Return a list of identities. Can be filtered by the status, department and type. Can also search by the email or name by keyword",
-        inputSchema: zodToJsonSchema(IdentityFiltersSchema),
-      },
-      {
-        name: "create_identity",
-        description:
-          "Create a new identity in the organization. Requires employeeStatus, employeeType, firstName, and lastName. Optional: displayName, primaryEmail, department, jobTitle, employeeId, lifecycle, customFields, manager, etc.",
-        inputSchema: zodToJsonSchema(CreateIdentitySchema),
-      },
-      {
-        name: "get_identity",
-        description: "Get a single identity by ID. Optionally expand with customFieldsMetadata.",
-        inputSchema: zodToJsonSchema(GetIdentitySchema),
-      },
-      {
-        name: "update_identity",
-        description:
-          "Update an existing identity. Pass identityId and any fields to update (employeeStatus, employeeType, displayName, primaryEmail, department, jobTitle, customFields, manager, etc.).",
-        inputSchema: zodToJsonSchema(UpdateIdentitySchema),
-      },
-      {
-        name: "delete_identity",
-        description: "Delete an identity by ID. Returns the deleted identity.",
-        inputSchema: zodToJsonSchema(DeleteIdentitySchema),
-      },
-      {
-        name: "get_services",
-        description:
-          "Return a list of services, along with the preview of the accounts. Can be searched by the service name by keyword",
-        inputSchema: zodToJsonSchema(ServiceFiltersSchema),
-      },
-      {
-        name: "get_service_accounts",
-        description:
-          "Return a list of accounts for a specific service. The serviceId can be obtained from the get_services tool. Can be searched by email/name of the account by keyword",
-        inputSchema: zodToJsonSchema(ServiceAccountFiltersSchema),
-      },
-      {
-        name: "get_people_accounts",
-        description:
-          "Return a list of SaaS accounts belonging to a person. The peopleId can be obtained from the get_identities tool. Can be filtered by role, two-factor authentication, and searched by service name or workspace name",
-        inputSchema: zodToJsonSchema(PeopleAccountsFiltersSchema),
-      },
-      {
-        name: "get_identity_field_configuration",
-        description:
-          "Get identity field configuration of an organization. Returns preset field configurations, field order, available fields, fields metadata, and field details. Optionally pass an identityId to get the effective configuration for a specific identity.",
-        inputSchema: zodToJsonSchema(GetIdentityFieldConfigurationSchema),
-      },
-      {
-        name: "get_identity_config",
-        description:
-          "Get configuration for identity fields of a specific identity. Required to filter by a specific identityId to see the effective configuration for that identity.",
-        inputSchema: zodToJsonSchema(IdentityConfigFiltersSchema),
-      },
-      {
-        name: "get_identity_custom_fields",
-        description:
-          "Get all identity custom fields configured for an organization. Returns field definitions, types (text, date, number, dropdown), and configurations.",
-        inputSchema: zodToJsonSchema(IdentityCustomFieldsFiltersSchema),
-      },
-      {
-        name: "check_identity_management_type",
-        description:
-          "Check Identity management type. Use this endpoint to determine the management type for an identity based on email or identityId. Returns the management type (e.g., hr_master, manual, unregistered).",
-        inputSchema: zodToJsonSchema(CheckIdentityManagementTypeSchema),
-      },
-      {
-        name: "get_identities_stats",
-        description:
-          "Get identities statistics for an organization. Returns management type counts, HR master integration information, and domain lists. Use this to understand the distribution of identities across different management types and HR systems.",
-        inputSchema: zodToJsonSchema(GetIdentitiesStatsSchema),
-      },
-      {
-        name: "merge_identities",
-        description:
-          "Merge identities in batch. Use this to merge multiple people entities or identity entities. Supports up to 50 merge operations per request. Can merge people entities (by peopleId) or identity entities (by identityId) in a single operation.",
-        inputSchema: zodToJsonSchema(MergeIdentitiesSchema),
-      },
-      {
-        name: "unmerge_identities",
-        description:
-          "Unmerge previously merged identity/people entities. Provide peopleIds, identityIds, or both to unmerge (up to 50 items each).",
-        inputSchema: zodToJsonSchema(UnmergeIdentitiesSchema),
-      },
-      {
-        name: "bulk_update_identities",
-        description:
-          "Bulk update multiple identities in a single request. Provide a list of identity IDs (1-50) and a set of field updates to apply to all of them. All identity update fields are optional.",
-        inputSchema: zodToJsonSchema(BulkUpdateIdentitiesSchema),
-      },
-      {
-        name: "get_identity_history",
-        description:
-          "Get the change history of a specific identity. Returns a paginated list of history records showing field-level changes, action types, sources, and actors.",
-        inputSchema: zodToJsonSchema(GetIdentityHistorySchema),
-      },
-      {
-        name: "archive_identity",
-        description:
-          "Toggle the archive flag for an identity. Returns the updated identity with the new archive state.",
-        inputSchema: zodToJsonSchema(ArchiveIdentitySchema),
-      },
-      {
-        name: "unregister_identity",
-        description:
-          "Toggle the unregistered management type for an identity. Returns the updated identity with the new management type.",
-        inputSchema: zodToJsonSchema(UnregisterIdentitySchema),
-      },
-      {
-        name: "create_identity_custom_field",
-        description:
-          "Create a new identity custom field for an organization. Defines a new field that can be used across all identities in the organization.",
-        inputSchema: zodToJsonSchema(CreateIdentityCustomFieldSchema),
-      },
-      {
-        name: "update_identity_custom_field",
-        description: "Update an existing identity custom field configuration. Can modify field name and code.",
-        inputSchema: zodToJsonSchema(UpdateIdentityCustomFieldSchema),
-      },
-      {
-        name: "delete_identity_custom_field",
-        description:
-          "Delete an identity custom field for an organization. Removes a custom field definition from the organization.",
-        inputSchema: zodToJsonSchema(DeleteIdentityCustomFieldSchema),
-      },
-    ],
-  };
-});
-
-// Tool handler type definition
-type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>;
-
-// Tool handlers map to reduce cognitive complexity
-const toolHandlers: Record<string, ToolHandler> = {
-  get_organization_info: async () => getOrganizationInfo(),
-  get_devices: async (input) => getDevices(DeviceFiltersSchema.parse(input)),
-  create_device: async (input) => createDevice(CreateDeviceSchema.parse(input)),
-  update_device: async (input) => updateDevice(UpdateDeviceSchema.parse(input)),
-  update_device_meta: async (input) => updateDeviceMeta(UpdateDeviceMetaSchema.parse(input)),
-  get_device_custom_fields: async () => getDeviceCustomFields(),
-  create_device_custom_field: async (input) => createDeviceCustomField(CreateDeviceCustomFieldSchema.parse(input)),
-  update_device_custom_field: async (input) => updateDeviceCustomField(UpdateDeviceCustomFieldSchema.parse(input)),
-  delete_device_custom_field: async (input) => deleteDeviceCustomField(DeleteDeviceCustomFieldSchema.parse(input)),
-  get_identities: async (input) => getIdentities(IdentityFiltersSchema.parse(input)),
-  create_identity: async (input) => createIdentity(CreateIdentitySchema.parse(input)),
-  get_identity: async (input) => getIdentity(GetIdentitySchema.parse(input)),
-  update_identity: async (input) => updateIdentity(UpdateIdentitySchema.parse(input)),
-  delete_identity: async (input) => deleteIdentity(DeleteIdentitySchema.parse(input)),
-  get_services: async (input) => getServices(ServiceFiltersSchema.parse(input)),
-  get_service_accounts: async (input) => getServiceAccounts(ServiceAccountFiltersSchema.parse(input)),
-  get_people_accounts: async (input) => getPeopleAccounts(PeopleAccountsFiltersSchema.parse(input)),
-  get_identity_field_configuration: async (input) =>
-    getIdentityFieldConfiguration(GetIdentityFieldConfigurationSchema.parse(input)),
-  get_identity_config: async (input) => getIdentityConfig(IdentityConfigFiltersSchema.parse(input)),
-  get_identity_custom_fields: async () => getIdentityCustomFields(),
-  check_identity_management_type: async (input) =>
-    checkIdentityManagementType(CheckIdentityManagementTypeSchema.parse(input)),
-  get_identities_stats: async (input) => getIdentitiesStats(GetIdentitiesStatsSchema.parse(input)),
-  merge_identities: async (input) => mergeIdentities(MergeIdentitiesSchema.parse(input)),
-  unmerge_identities: async (input) => unmergeIdentities(UnmergeIdentitiesSchema.parse(input)),
-  bulk_update_identities: async (input) => bulkUpdateIdentities(BulkUpdateIdentitiesSchema.parse(input)),
-  get_identity_history: async (input) => getIdentityHistory(GetIdentityHistorySchema.parse(input)),
-  archive_identity: async (input) => archiveIdentity(ArchiveIdentitySchema.parse(input)),
-  unregister_identity: async (input) => unregisterIdentity(UnregisterIdentitySchema.parse(input)),
-  create_identity_custom_field: async (input) =>
-    createIdentityCustomField(CreateIdentityCustomFieldSchema.parse(input)),
-  update_identity_custom_field: async (input) =>
-    updateIdentityCustomField(UpdateIdentityCustomFieldSchema.parse(input)),
-  delete_identity_custom_field: async (input) =>
-    deleteIdentityCustomField(DeleteIdentityCustomFieldSchema.parse(input)),
-};
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const toolName = request.params.name;
-  const input = request.params.arguments || {};
-  try {
-    const handler = toolHandlers[toolName];
-    if (!handler) {
-      return {
-        content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
-        isError: true,
-      };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--http") {
+      transport = "http";
+    } else if (arg === "--stdio") {
+      transport = "stdio";
+    } else if (arg === "--port") {
+      const next = argv[++i];
+      if (!next) throw new Error("--port requires a value");
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+        throw new Error(`Invalid --port value: ${next}`);
+      }
+      port = parsed;
+    } else if (arg === "--host") {
+      const next = argv[++i];
+      if (!next) throw new Error("--host requires a value");
+      host = next;
     }
-
-    const response = await handler(input);
-    return {
-      content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
-      isError: false,
-    };
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      const errorDetails = error.errors
-        .map((err) => {
-          return `${err.path.join(".")}: ${err.message}`;
-        })
-        .join("\n");
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Invalid input:\n${errorDetails}`,
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    if (isAdminaError(error)) {
-      return {
-        content: [{ type: "text", text: formatAdminaError(error) }],
-        isError: true,
-      };
-    }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
   }
-});
 
-// Start the server
-const serverTransport = new StdioServerTransport();
-server.connect(serverTransport);
+  if (!Number.isFinite(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid MCP_HTTP_PORT value: ${env.MCP_HTTP_PORT}`);
+  }
+
+  return {
+    transport,
+    http: { port, host },
+  };
+}
+
+async function main(): Promise<void> {
+  const opts = parseCliOptions(process.argv.slice(2), process.env);
+
+  if (opts.transport === "http") {
+    const handle = await runHttp(opts.http);
+    console.error(`[admina-mcp-server] listening on http://${handle.host}:${handle.port}/mcp`);
+    return;
+  }
+
+  await runStdio();
+}
+
+// Only run when invoked as the entry point; `parseCliOptions` is also exported for tests.
+// Jest sets JEST_WORKER_ID; skip auto-run in that case.
+if (!process.env.JEST_WORKER_ID) {
+  main().catch((err) => {
+    console.error("[admina-mcp-server] fatal:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { HttpOptions, runHttp } from "./transports/http.js";
+import { type HttpOptions, runHttp } from "./transports/http.js";
 import { runStdio } from "./transports/stdio.js";
 
 export interface CliOptions {

--- a/src/server.ts
+++ b/src/server.ts
@@ -319,7 +319,7 @@ const toolDefinitions = [
 export function createServer(): Server {
   const server = new Server(
     {
-      name: "admina-mpc",
+      name: "admina-mcp",
       version: "1.0.0",
     },
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,386 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { formatAdminaError, isAdminaError } from "./common/errors.js";
+import { CreateIdentityCustomFieldSchema, createIdentityCustomField } from "./tools/createIdentityCustomField.js";
+import { DeleteIdentityCustomFieldSchema, deleteIdentityCustomField } from "./tools/deleteIdentityCustomField.js";
+import { IdentityConfigFiltersSchema, getIdentityConfig } from "./tools/getIdentityConfig.js";
+import { IdentityCustomFieldsFiltersSchema, getIdentityCustomFields } from "./tools/getIdentityCustomField.js";
+import {
+  ArchiveIdentitySchema,
+  BulkUpdateIdentitiesSchema,
+  CheckIdentityManagementTypeSchema,
+  CreateDeviceCustomFieldSchema,
+  CreateDeviceSchema,
+  CreateIdentitySchema,
+  DeleteDeviceCustomFieldSchema,
+  DeleteIdentitySchema,
+  DeviceCustomFieldsSchema,
+  DeviceFiltersSchema,
+  GetIdentitiesStatsSchema,
+  GetIdentityFieldConfigurationSchema,
+  GetIdentityHistorySchema,
+  GetIdentitySchema,
+  IdentityFiltersSchema,
+  MergeIdentitiesSchema,
+  OrganizationInfoSchema,
+  PeopleAccountsFiltersSchema,
+  ServiceAccountFiltersSchema,
+  ServiceFiltersSchema,
+  UnmergeIdentitiesSchema,
+  UnregisterIdentitySchema,
+  UpdateDeviceCustomFieldSchema,
+  UpdateDeviceMetaSchema,
+  UpdateDeviceSchema,
+  UpdateIdentitySchema,
+  archiveIdentity,
+  bulkUpdateIdentities,
+  checkIdentityManagementType,
+  createDevice,
+  createDeviceCustomField,
+  createIdentity,
+  deleteDeviceCustomField,
+  deleteIdentity,
+  getDeviceCustomFields,
+  getDevices,
+  getIdentities,
+  getIdentitiesStats,
+  getIdentity,
+  getIdentityFieldConfiguration,
+  getIdentityHistory,
+  getOrganizationInfo,
+  getPeopleAccounts,
+  getServiceAccounts,
+  getServices,
+  mergeIdentities,
+  unmergeIdentities,
+  unregisterIdentity,
+  updateDevice,
+  updateDeviceCustomField,
+  updateDeviceMeta,
+  updateIdentity,
+} from "./tools/index.js";
+import { UpdateIdentityCustomFieldSchema, updateIdentityCustomField } from "./tools/updateIdentityCustomField.js";
+
+type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>;
+
+const toolHandlers: Record<string, ToolHandler> = {
+  get_organization_info: async () => getOrganizationInfo(),
+  get_devices: async (input) => getDevices(DeviceFiltersSchema.parse(input)),
+  create_device: async (input) => createDevice(CreateDeviceSchema.parse(input)),
+  update_device: async (input) => updateDevice(UpdateDeviceSchema.parse(input)),
+  update_device_meta: async (input) => updateDeviceMeta(UpdateDeviceMetaSchema.parse(input)),
+  get_device_custom_fields: async () => getDeviceCustomFields(),
+  create_device_custom_field: async (input) => createDeviceCustomField(CreateDeviceCustomFieldSchema.parse(input)),
+  update_device_custom_field: async (input) => updateDeviceCustomField(UpdateDeviceCustomFieldSchema.parse(input)),
+  delete_device_custom_field: async (input) => deleteDeviceCustomField(DeleteDeviceCustomFieldSchema.parse(input)),
+  get_identities: async (input) => getIdentities(IdentityFiltersSchema.parse(input)),
+  create_identity: async (input) => createIdentity(CreateIdentitySchema.parse(input)),
+  get_identity: async (input) => getIdentity(GetIdentitySchema.parse(input)),
+  update_identity: async (input) => updateIdentity(UpdateIdentitySchema.parse(input)),
+  delete_identity: async (input) => deleteIdentity(DeleteIdentitySchema.parse(input)),
+  get_services: async (input) => getServices(ServiceFiltersSchema.parse(input)),
+  get_service_accounts: async (input) => getServiceAccounts(ServiceAccountFiltersSchema.parse(input)),
+  get_people_accounts: async (input) => getPeopleAccounts(PeopleAccountsFiltersSchema.parse(input)),
+  get_identity_field_configuration: async (input) =>
+    getIdentityFieldConfiguration(GetIdentityFieldConfigurationSchema.parse(input)),
+  get_identity_config: async (input) => getIdentityConfig(IdentityConfigFiltersSchema.parse(input)),
+  get_identity_custom_fields: async () => getIdentityCustomFields(),
+  check_identity_management_type: async (input) =>
+    checkIdentityManagementType(CheckIdentityManagementTypeSchema.parse(input)),
+  get_identities_stats: async (input) => getIdentitiesStats(GetIdentitiesStatsSchema.parse(input)),
+  merge_identities: async (input) => mergeIdentities(MergeIdentitiesSchema.parse(input)),
+  unmerge_identities: async (input) => unmergeIdentities(UnmergeIdentitiesSchema.parse(input)),
+  bulk_update_identities: async (input) => bulkUpdateIdentities(BulkUpdateIdentitiesSchema.parse(input)),
+  get_identity_history: async (input) => getIdentityHistory(GetIdentityHistorySchema.parse(input)),
+  archive_identity: async (input) => archiveIdentity(ArchiveIdentitySchema.parse(input)),
+  unregister_identity: async (input) => unregisterIdentity(UnregisterIdentitySchema.parse(input)),
+  create_identity_custom_field: async (input) =>
+    createIdentityCustomField(CreateIdentityCustomFieldSchema.parse(input)),
+  update_identity_custom_field: async (input) =>
+    updateIdentityCustomField(UpdateIdentityCustomFieldSchema.parse(input)),
+  delete_identity_custom_field: async (input) =>
+    deleteIdentityCustomField(DeleteIdentityCustomFieldSchema.parse(input)),
+};
+
+const toolDefinitions = [
+  {
+    name: "get_organization_info",
+    description: "Get information about the organization including name, unique name, status, system language, etc.",
+    inputSchema: zodToJsonSchema(OrganizationInfoSchema),
+  },
+  {
+    name: "get_devices",
+    description: `Get a list of devices for an organization using advanced search and filtering.
+
+## Key Features
+- Combine query parameters (pagination, sorting) with body parameters (filtering)
+- Support for text search, field-specific filters, and complex queries
+- Pagination with cursor-based navigation
+
+## Example Usage
+**Find first 5 devices for user with email "someone@gmail.com":**
+- Query: limit=5
+- Body: {"searchTerm": "someone@gmail.com", "searchFields": ["people.primaryEmail"]}
+
+## Pro Tips
+- **1**: Always make sure understand the definition of the fields (preset and custom fields) before using them.
+- **2**: If user search devices by category: pc, phone or other, please use body.type to filter devices by category.
+- **3**: Always to understand what are current sub types of the devices. If the user search information relate to sub types, Please use body.filters.["preset.subtype"] to filter devices by sub types.
+- **4**: We don't really need to use searchFields parameter to the search results in all fields, only use it when the user search information relate to specific fields.
+- **5**: If user want to filter devices by status, please use body.filters.["preset.status"].eq to filter devices by status.
+- **5.1**: Unassigned devices status should be "in_stock" or "decommissioned".
+- **6**: If user want to filter devices by preset fields or custom fields, please check the field.kind first, we only support date, number, dropdown kind of fields.
+- **6.1**: If the field.kind is date, please use body.filters.["preset.field_name"].minDate or body.filters.["custom.attributeCode"].minDate and body.filters.["preset.field_name"].maxDate or body.filters.["custom.attributeCode"].maxDate to filter devices by date range.
+- **6.2**: If the field.kind is number, please use body.filters.["preset.field_name"].minNumber or body.filters.["custom.attributeCode"].minNumber and body.filters.["preset.field_name"].maxNumber or body.filters.["custom.attributeCode"].maxNumber to filter devices by number range.
+- **6.3**: If the preset field field.kind is dropdown, please use body.filters.["preset.field_name"].eq or body.filters.["custom.attributeCode"].eq to filter devices by dropdown value.
+- **7**: Combine multiple filters examples: {"preset.status":{"eq":"active"},"preset.subtype":{"eq":"desktop_pc"},"custom.custom_xxx":{"eq":"1"},"custom.dt_13":{"minDate":"2025-12-23","maxDate":"2025-12-25"},"custom.drp_4":{"eq":"1"}}`,
+    inputSchema: zodToJsonSchema(DeviceFiltersSchema),
+  },
+  {
+    name: "create_device",
+    description:
+      "Create a new device for an organization. Requires device type (subtype), asset number, and model name. Can include optional preset fields and custom fields.",
+    inputSchema: zodToJsonSchema(CreateDeviceSchema),
+  },
+  {
+    name: "update_device",
+    description:
+      "Update an existing device's information. Can update preset fields, custom fields, and device properties. Note: fields.preset.asset_number, fields.preset.subtype, fields.preset.model_name are always required.",
+    inputSchema: zodToJsonSchema(UpdateDeviceSchema),
+  },
+  {
+    name: "update_device_meta",
+    description:
+      "Update device's meta information including assignment info (peopleId, status, dates) and location. Use this to assign/unassign devices to people. When unassigned, status should be 'in_stock' or 'decommissioned'. When assigned without status, defaults to 'active'.",
+    inputSchema: zodToJsonSchema(UpdateDeviceMetaSchema),
+  },
+  {
+    name: "get_device_custom_fields",
+    description:
+      "Get all custom fields configured for an organization's devices. Returns field definitions, types (text, date, number, dropdown), and configurations.",
+    inputSchema: zodToJsonSchema(DeviceCustomFieldsSchema),
+  },
+  {
+    name: "create_device_custom_field",
+    description:
+      "Create a new custom field for organization devices. Defines a new field that can be used across all devices in the organization.",
+    inputSchema: zodToJsonSchema(CreateDeviceCustomFieldSchema),
+  },
+  {
+    name: "update_device_custom_field",
+    description:
+      "Update an existing device custom field configuration. Can modify field name, code, visibility for device types, and dropdown configuration.",
+    inputSchema: zodToJsonSchema(UpdateDeviceCustomFieldSchema),
+  },
+  {
+    name: "delete_device_custom_field",
+    description: "Delete a device custom field configuration. Removes a custom field definition from the organization.",
+    inputSchema: zodToJsonSchema(DeleteDeviceCustomFieldSchema),
+  },
+  {
+    name: "get_identities",
+    description:
+      "Return a list of identities. Can be filtered by the status, department and type. Can also search by the email or name by keyword",
+    inputSchema: zodToJsonSchema(IdentityFiltersSchema),
+  },
+  {
+    name: "create_identity",
+    description:
+      "Create a new identity in the organization. Requires employeeStatus, employeeType, firstName, and lastName. Optional: displayName, primaryEmail, department, jobTitle, employeeId, lifecycle, customFields, manager, etc.",
+    inputSchema: zodToJsonSchema(CreateIdentitySchema),
+  },
+  {
+    name: "get_identity",
+    description: "Get a single identity by ID. Optionally expand with customFieldsMetadata.",
+    inputSchema: zodToJsonSchema(GetIdentitySchema),
+  },
+  {
+    name: "update_identity",
+    description:
+      "Update an existing identity. Pass identityId and any fields to update (employeeStatus, employeeType, displayName, primaryEmail, department, jobTitle, customFields, manager, etc.).",
+    inputSchema: zodToJsonSchema(UpdateIdentitySchema),
+  },
+  {
+    name: "delete_identity",
+    description: "Delete an identity by ID. Returns the deleted identity.",
+    inputSchema: zodToJsonSchema(DeleteIdentitySchema),
+  },
+  {
+    name: "get_services",
+    description:
+      "Return a list of services, along with the preview of the accounts. Can be searched by the service name by keyword",
+    inputSchema: zodToJsonSchema(ServiceFiltersSchema),
+  },
+  {
+    name: "get_service_accounts",
+    description:
+      "Return a list of accounts for a specific service. The serviceId can be obtained from the get_services tool. Can be searched by email/name of the account by keyword",
+    inputSchema: zodToJsonSchema(ServiceAccountFiltersSchema),
+  },
+  {
+    name: "get_people_accounts",
+    description:
+      "Return a list of SaaS accounts belonging to a person. The peopleId can be obtained from the get_identities tool. Can be filtered by role, two-factor authentication, and searched by service name or workspace name",
+    inputSchema: zodToJsonSchema(PeopleAccountsFiltersSchema),
+  },
+  {
+    name: "get_identity_field_configuration",
+    description:
+      "Get identity field configuration of an organization. Returns preset field configurations, field order, available fields, fields metadata, and field details. Optionally pass an identityId to get the effective configuration for a specific identity.",
+    inputSchema: zodToJsonSchema(GetIdentityFieldConfigurationSchema),
+  },
+  {
+    name: "get_identity_config",
+    description:
+      "Get configuration for identity fields of a specific identity. Required to filter by a specific identityId to see the effective configuration for that identity.",
+    inputSchema: zodToJsonSchema(IdentityConfigFiltersSchema),
+  },
+  {
+    name: "get_identity_custom_fields",
+    description:
+      "Get all identity custom fields configured for an organization. Returns field definitions, types (text, date, number, dropdown), and configurations.",
+    inputSchema: zodToJsonSchema(IdentityCustomFieldsFiltersSchema),
+  },
+  {
+    name: "check_identity_management_type",
+    description:
+      "Check Identity management type. Use this endpoint to determine the management type for an identity based on email or identityId. Returns the management type (e.g., hr_master, manual, unregistered).",
+    inputSchema: zodToJsonSchema(CheckIdentityManagementTypeSchema),
+  },
+  {
+    name: "get_identities_stats",
+    description:
+      "Get identities statistics for an organization. Returns management type counts, HR master integration information, and domain lists. Use this to understand the distribution of identities across different management types and HR systems.",
+    inputSchema: zodToJsonSchema(GetIdentitiesStatsSchema),
+  },
+  {
+    name: "merge_identities",
+    description:
+      "Merge identities in batch. Use this to merge multiple people entities or identity entities. Supports up to 50 merge operations per request. Can merge people entities (by peopleId) or identity entities (by identityId) in a single operation.",
+    inputSchema: zodToJsonSchema(MergeIdentitiesSchema),
+  },
+  {
+    name: "unmerge_identities",
+    description:
+      "Unmerge previously merged identity/people entities. Provide peopleIds, identityIds, or both to unmerge (up to 50 items each).",
+    inputSchema: zodToJsonSchema(UnmergeIdentitiesSchema),
+  },
+  {
+    name: "bulk_update_identities",
+    description:
+      "Bulk update multiple identities in a single request. Provide a list of identity IDs (1-50) and a set of field updates to apply to all of them. All identity update fields are optional.",
+    inputSchema: zodToJsonSchema(BulkUpdateIdentitiesSchema),
+  },
+  {
+    name: "get_identity_history",
+    description:
+      "Get the change history of a specific identity. Returns a paginated list of history records showing field-level changes, action types, sources, and actors.",
+    inputSchema: zodToJsonSchema(GetIdentityHistorySchema),
+  },
+  {
+    name: "archive_identity",
+    description: "Toggle the archive flag for an identity. Returns the updated identity with the new archive state.",
+    inputSchema: zodToJsonSchema(ArchiveIdentitySchema),
+  },
+  {
+    name: "unregister_identity",
+    description:
+      "Toggle the unregistered management type for an identity. Returns the updated identity with the new management type.",
+    inputSchema: zodToJsonSchema(UnregisterIdentitySchema),
+  },
+  {
+    name: "create_identity_custom_field",
+    description:
+      "Create a new identity custom field for an organization. Defines a new field that can be used across all identities in the organization.",
+    inputSchema: zodToJsonSchema(CreateIdentityCustomFieldSchema),
+  },
+  {
+    name: "update_identity_custom_field",
+    description: "Update an existing identity custom field configuration. Can modify field name and code.",
+    inputSchema: zodToJsonSchema(UpdateIdentityCustomFieldSchema),
+  },
+  {
+    name: "delete_identity_custom_field",
+    description:
+      "Delete an identity custom field for an organization. Removes a custom field definition from the organization.",
+    inputSchema: zodToJsonSchema(DeleteIdentityCustomFieldSchema),
+  },
+];
+
+/**
+ * Builds a fresh MCP Server with all Admina tools registered.
+ *
+ * Transports (stdio, HTTP) call this once per connection — in the HTTP case
+ * that means once per request, because the Streamable HTTP transport is
+ * stateless in this server.
+ */
+export function createServer(): Server {
+  const server = new Server(
+    {
+      name: "admina-mpc",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolDefinitions }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name;
+    const input = request.params.arguments || {};
+    try {
+      const handler = toolHandlers[toolName];
+      if (!handler) {
+        return {
+          content: [{ type: "text", text: `Unknown tool: ${toolName}` }],
+          isError: true,
+        };
+      }
+
+      const response = await handler(input);
+      return {
+        content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        isError: false,
+      };
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const errorDetails = error.errors.map((err) => `${err.path.join(".")}: ${err.message}`).join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Invalid input:\n${errorDetails}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (isAdminaError(error)) {
+        return {
+          content: [{ type: "text", text: formatAdminaError(error) }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/src/test/admina-api.test.ts
+++ b/src/test/admina-api.test.ts
@@ -1,0 +1,96 @@
+import axios from "axios";
+import { AdminaApiClient, MCP_USAGE_TRACKING_HEADERS, getClient, resetClient } from "../admina-api.js";
+import { withCredentials } from "../context.js";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("admina-api getClient", () => {
+  const originalKey = process.env.ADMINA_API_KEY;
+  const originalOrg = process.env.ADMINA_ORGANIZATION_ID;
+
+  beforeEach(() => {
+    resetClient();
+    mockedAxios.get.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    // biome-ignore lint/performance/noDelete: env-var-unset semantics matter; `= undefined` sets the string "undefined"
+    if (originalKey === undefined) delete process.env.ADMINA_API_KEY;
+    else process.env.ADMINA_API_KEY = originalKey;
+    // biome-ignore lint/performance/noDelete: env-var-unset semantics matter; `= undefined` sets the string "undefined"
+    if (originalOrg === undefined) delete process.env.ADMINA_ORGANIZATION_ID;
+    else process.env.ADMINA_ORGANIZATION_ID = originalOrg;
+  });
+
+  describe("without credential context (stdio mode)", () => {
+    it("returns a singleton built from env vars", () => {
+      process.env.ADMINA_API_KEY = "env-key";
+      process.env.ADMINA_ORGANIZATION_ID = "env-org";
+
+      const a = getClient();
+      const b = getClient();
+
+      expect(a).toBeInstanceOf(AdminaApiClient);
+      expect(a).toBe(b);
+    });
+
+    it("throws when env vars are missing", () => {
+      // biome-ignore lint/performance/noDelete: env-var-unset semantics matter; `= undefined` sets the string "undefined"
+      delete process.env.ADMINA_API_KEY;
+      // biome-ignore lint/performance/noDelete: env-var-unset semantics matter; `= undefined` sets the string "undefined"
+      delete process.env.ADMINA_ORGANIZATION_ID;
+      expect(() => getClient()).toThrow("ADMINA_API_KEY and ADMINA_ORGANIZATION_ID must be set");
+    });
+  });
+
+  describe("inside withCredentials (HTTP mode)", () => {
+    it("uses context credentials and ignores env vars", async () => {
+      process.env.ADMINA_API_KEY = "env-key";
+      process.env.ADMINA_ORGANIZATION_ID = "env-org";
+
+      await withCredentials({ apiKey: "ctx-key", organizationId: "ctx-org" }, async () => {
+        const client = getClient();
+        await client.makeApiCall("/organizations/whatever", new URLSearchParams());
+
+        const [url, config] = mockedAxios.get.mock.calls[0];
+        expect(url).toContain("/organizations/ctx-org/");
+        expect(config?.headers).toMatchObject({
+          Authorization: "Bearer ctx-key",
+          ...MCP_USAGE_TRACKING_HEADERS,
+        });
+      });
+    });
+
+    it("does not share the instance with the env-backed singleton", () => {
+      process.env.ADMINA_API_KEY = "env-key";
+      process.env.ADMINA_ORGANIZATION_ID = "env-org";
+
+      const envClient = getClient();
+      const ctxClient = withCredentials({ apiKey: "ctx-key", organizationId: "ctx-org" }, () => getClient());
+
+      expect(ctxClient).not.toBe(envClient);
+    });
+
+    it("isolates clients across concurrent scopes", async () => {
+      const seenOrgIds: string[] = [];
+
+      mockedAxios.get.mockImplementation((url: string) => {
+        const m = url.match(/\/organizations\/([^/]+)\//);
+        if (m) seenOrgIds.push(m[1]);
+        return Promise.resolve({ data: {} });
+      });
+
+      const run = async (apiKey: string, organizationId: string) =>
+        withCredentials({ apiKey, organizationId }, async () => {
+          const client = getClient();
+          await client.makeApiCall("/organizations/me", new URLSearchParams());
+        });
+
+      await Promise.all([run("keyA", "orgA"), run("keyB", "orgB"), run("keyC", "orgC")]);
+
+      expect(seenOrgIds.sort()).toEqual(["orgA", "orgB", "orgC"]);
+    });
+  });
+});

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1,0 +1,63 @@
+import { DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, parseCliOptions } from "../index.js";
+
+describe("parseCliOptions", () => {
+  it("defaults to stdio with no args or env", () => {
+    const opts = parseCliOptions([], {});
+    expect(opts.transport).toBe("stdio");
+    expect(opts.http.port).toBe(DEFAULT_HTTP_PORT);
+    expect(opts.http.host).toBe(DEFAULT_HTTP_HOST);
+  });
+
+  it("selects http via --http flag", () => {
+    const opts = parseCliOptions(["--http"], {});
+    expect(opts.transport).toBe("http");
+  });
+
+  it("selects http via MCP_TRANSPORT=http", () => {
+    const opts = parseCliOptions([], { MCP_TRANSPORT: "http" });
+    expect(opts.transport).toBe("http");
+  });
+
+  it("reads port and host from flags", () => {
+    const opts = parseCliOptions(["--http", "--port", "4000", "--host", "0.0.0.0"], {});
+    expect(opts.http).toEqual({ port: 4000, host: "0.0.0.0" });
+  });
+
+  it("reads port and host from env", () => {
+    const opts = parseCliOptions([], {
+      MCP_TRANSPORT: "http",
+      MCP_HTTP_PORT: "4001",
+      MCP_HTTP_HOST: "::1",
+    });
+    expect(opts.http).toEqual({ port: 4001, host: "::1" });
+  });
+
+  it("flags override env", () => {
+    const opts = parseCliOptions(["--port", "5000"], {
+      MCP_HTTP_PORT: "4000",
+    });
+    expect(opts.http.port).toBe(5000);
+  });
+
+  it("rejects invalid port flag value", () => {
+    expect(() => parseCliOptions(["--port", "not-a-number"], {})).toThrow(/Invalid --port/);
+    expect(() => parseCliOptions(["--port", "70000"], {})).toThrow(/Invalid --port/);
+  });
+
+  it("rejects --port without value", () => {
+    expect(() => parseCliOptions(["--port"], {})).toThrow(/--port requires a value/);
+  });
+
+  it("rejects --host without value", () => {
+    expect(() => parseCliOptions(["--host"], {})).toThrow(/--host requires a value/);
+  });
+
+  it("rejects invalid MCP_HTTP_PORT env value", () => {
+    expect(() => parseCliOptions([], { MCP_HTTP_PORT: "abc" })).toThrow(/Invalid MCP_HTTP_PORT/);
+  });
+
+  it("allows explicit --stdio", () => {
+    const opts = parseCliOptions(["--stdio"], { MCP_TRANSPORT: "http" });
+    expect(opts.transport).toBe("stdio");
+  });
+});

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -1,0 +1,46 @@
+import { getCurrentCredentials, withCredentials } from "../context.js";
+
+describe("context", () => {
+  it("returns undefined outside of a withCredentials scope", () => {
+    expect(getCurrentCredentials()).toBeUndefined();
+  });
+
+  it("exposes credentials inside a synchronous scope", () => {
+    const creds = { apiKey: "k1", organizationId: "o1" };
+    const seen = withCredentials(creds, () => getCurrentCredentials());
+    expect(seen).toEqual(creds);
+  });
+
+  it("exposes credentials across awaits inside the scope", async () => {
+    const creds = { apiKey: "k2", organizationId: "o2" };
+    const seen = await withCredentials(creds, async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+      return getCurrentCredentials();
+    });
+    expect(seen).toEqual(creds);
+  });
+
+  it("isolates credentials across concurrent scopes", async () => {
+    const credsA = { apiKey: "keyA", organizationId: "orgA" };
+    const credsB = { apiKey: "keyB", organizationId: "orgB" };
+
+    const run = async (creds: typeof credsA) =>
+      withCredentials(creds, async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        return getCurrentCredentials();
+      });
+
+    const [seenA, seenB] = await Promise.all([run(credsA), run(credsB)]);
+
+    expect(seenA).toEqual(credsA);
+    expect(seenB).toEqual(credsB);
+  });
+
+  it("clears the scope after the callback resolves", async () => {
+    await withCredentials({ apiKey: "k", organizationId: "o" }, async () => {
+      await Promise.resolve();
+    });
+    expect(getCurrentCredentials()).toBeUndefined();
+  });
+});

--- a/src/test/transports/http.test.ts
+++ b/src/test/transports/http.test.ts
@@ -1,0 +1,174 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import axios from "axios";
+import { resetClient } from "../../admina-api.js";
+import { HttpHandle, runHttp } from "../../transports/http.js";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+type AxiosCall = { method: string; url: string; headers: Record<string, string>; body?: unknown };
+
+function installAxiosCapture(sink: AxiosCall[], canned: unknown) {
+  const capture =
+    (method: string) =>
+    (url: string, ...rest: any[]) => {
+      const hasBody = method === "post" || method === "put" || method === "patch";
+      const config = hasBody ? rest[1] : rest[0];
+      const body = hasBody ? rest[0] : undefined;
+      sink.push({
+        method,
+        url,
+        headers: (config?.headers ?? {}) as Record<string, string>,
+        body,
+      });
+      return Promise.resolve({ data: canned });
+    };
+  mockedAxios.get.mockImplementation(capture("get") as any);
+  mockedAxios.post.mockImplementation(capture("post") as any);
+  mockedAxios.patch.mockImplementation(capture("patch") as any);
+  mockedAxios.put.mockImplementation(capture("put") as any);
+  mockedAxios.delete.mockImplementation(capture("delete") as any);
+}
+
+async function startServer(): Promise<HttpHandle> {
+  return runHttp({ port: 0, host: "127.0.0.1" });
+}
+
+function endpoint(h: HttpHandle): string {
+  return `http://${h.host}:${h.port}/mcp`;
+}
+
+function rawPost(url: string, headers: Record<string, string>, body: string): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...headers },
+    body,
+  });
+}
+
+describe("runHttp", () => {
+  let handle: HttpHandle;
+
+  beforeEach(async () => {
+    resetClient();
+    mockedAxios.get.mockReset();
+    mockedAxios.post.mockReset();
+    mockedAxios.patch.mockReset();
+    mockedAxios.put.mockReset();
+    mockedAxios.delete.mockReset();
+    handle = await startServer();
+  });
+
+  afterEach(async () => {
+    await handle.close();
+    jest.clearAllMocks();
+  });
+
+  describe("auth", () => {
+    it("rejects requests without Authorization header (401)", async () => {
+      const res = await rawPost(endpoint(handle), { "X-Admina-Organization-Id": "org-1" }, "{}");
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("unauthorized");
+    });
+
+    it("rejects malformed Authorization header (401)", async () => {
+      const res = await rawPost(
+        endpoint(handle),
+        { Authorization: "Token abc", "X-Admina-Organization-Id": "org-1" },
+        "{}",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects empty bearer token (401)", async () => {
+      const res = await rawPost(
+        endpoint(handle),
+        { Authorization: "Bearer   ", "X-Admina-Organization-Id": "org-1" },
+        "{}",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects requests missing X-Admina-Organization-Id (401)", async () => {
+      const res = await rawPost(endpoint(handle), { Authorization: "Bearer key-1" }, "{}");
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("unauthorized");
+      expect(body.message).toMatch(/Organization/);
+    });
+  });
+
+  describe("routing", () => {
+    it("returns 404 for unknown paths", async () => {
+      const url = `http://${handle.host}:${handle.port}/health`;
+      const res = await fetch(url, { method: "GET" });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("end-to-end via MCP client", () => {
+    const makeClient = async (apiKey: string, organizationId: string) => {
+      const transport = new StreamableHTTPClientTransport(new URL(endpoint(handle)), {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "X-Admina-Organization-Id": organizationId,
+          },
+        },
+      });
+      const client = new Client({ name: "test-client", version: "0.0.0" }, {});
+      await client.connect(transport);
+      return { client, transport };
+    };
+
+    it("lists tools via MCP protocol", async () => {
+      installAxiosCapture([], {});
+      const { client, transport } = await makeClient("key-1", "org-1");
+
+      const { tools } = await client.listTools();
+      expect(tools.length).toBeGreaterThan(10);
+      expect(tools.map((t) => t.name)).toContain("get_organization_info");
+
+      await client.close();
+      await transport.close();
+    });
+
+    it("calls a tool and forwards the configured credentials to Admina", async () => {
+      const calls: AxiosCall[] = [];
+      installAxiosCapture(calls, { id: "org-1", name: "Tenant 1" });
+
+      const { client, transport } = await makeClient("key-alpha", "org-alpha");
+
+      const result = await client.callTool({ name: "get_organization_info", arguments: {} });
+      expect(result.isError).toBeFalsy();
+
+      const call = calls.find((c) => /\/organizations\/org-alpha(\/|\?|$)/.test(c.url));
+      expect(call).toBeDefined();
+      expect(call?.headers.Authorization).toBe("Bearer key-alpha");
+
+      await client.close();
+      await transport.close();
+    });
+
+    it("isolates credentials across concurrent requests from different tenants", async () => {
+      const calls: AxiosCall[] = [];
+      installAxiosCapture(calls, { id: "x" });
+
+      const runTenant = async (apiKey: string, organizationId: string) => {
+        const { client, transport } = await makeClient(apiKey, organizationId);
+        await client.callTool({ name: "get_organization_info", arguments: {} });
+        await client.close();
+        await transport.close();
+      };
+
+      await Promise.all([runTenant("key-A", "org-A"), runTenant("key-B", "org-B"), runTenant("key-C", "org-C")]);
+
+      const byOrg = (org: string) => calls.find((c) => new RegExp(`/organizations/${org}(/|\\?|$)`).test(c.url));
+      expect(byOrg("org-A")?.headers.Authorization).toBe("Bearer key-A");
+      expect(byOrg("org-B")?.headers.Authorization).toBe("Bearer key-B");
+      expect(byOrg("org-C")?.headers.Authorization).toBe("Bearer key-C");
+    });
+  });
+});

--- a/src/test/transports/http.test.ts
+++ b/src/test/transports/http.test.ts
@@ -31,6 +31,52 @@ function installAxiosCapture(sink: AxiosCall[], canned: unknown) {
   mockedAxios.delete.mockImplementation(capture("delete") as any);
 }
 
+// Install axios mocks that only resolve once `release()` is called. Used to
+// prove credential isolation under genuine concurrent in-flight execution:
+// every concurrent handler's axios call parks in the same mock until we
+// release them, so all ALS contexts must be live simultaneously.
+function installGatedAxios(sink: AxiosCall[], canned: unknown) {
+  const waiters: Array<() => void> = [];
+  const gate = new Promise<void>((resolve) => {
+    waiters.push(resolve);
+  });
+  let releaseResolve: (() => void) | null = null;
+  const release = new Promise<void>((resolve) => {
+    releaseResolve = resolve;
+  });
+
+  const impl =
+    (method: string) =>
+    async (url: string, ...rest: any[]) => {
+      const hasBody = method === "post" || method === "put" || method === "patch";
+      const config = hasBody ? rest[1] : rest[0];
+      const body = hasBody ? rest[0] : undefined;
+      sink.push({ method, url, headers: (config?.headers ?? {}) as Record<string, string>, body });
+      await release;
+      return { data: canned };
+    };
+
+  mockedAxios.get.mockImplementation(impl("get") as any);
+  mockedAxios.post.mockImplementation(impl("post") as any);
+  mockedAxios.patch.mockImplementation(impl("patch") as any);
+  mockedAxios.put.mockImplementation(impl("put") as any);
+  mockedAxios.delete.mockImplementation(impl("delete") as any);
+
+  return {
+    waitUntilInFlight: async (count: number) => {
+      // Poll the sink until `count` calls are recorded.
+      const deadline = Date.now() + 3000;
+      while (sink.length < count && Date.now() < deadline) {
+        await new Promise((r) => setImmediate(r));
+      }
+      if (sink.length < count) throw new Error(`Only ${sink.length}/${count} calls reached axios before timeout`);
+    },
+    release: () => releaseResolve?.(),
+    gate,
+    waiters,
+  };
+}
+
 async function startServer(): Promise<HttpHandle> {
   return runHttp({ port: 0, host: "127.0.0.1" });
 }
@@ -98,13 +144,73 @@ describe("runHttp", () => {
       expect(body.error).toBe("unauthorized");
       expect(body.message).toMatch(/Organization/);
     });
+
+    it("rejects X-Admina-Organization-Id with path-injection characters (400)", async () => {
+      const res = await rawPost(
+        endpoint(handle),
+        { Authorization: "Bearer key-1", "X-Admina-Organization-Id": "org/../admin" },
+        "{}",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_organization_id");
+    });
   });
 
-  describe("routing", () => {
+  describe("method + path routing", () => {
     it("returns 404 for unknown paths", async () => {
       const url = `http://${handle.host}:${handle.port}/health`;
       const res = await fetch(url, { method: "GET" });
       expect(res.status).toBe(404);
+    });
+
+    it("returns 405 for GET /mcp (stateless mode supports POST only)", async () => {
+      const res = await fetch(endpoint(handle), {
+        method: "GET",
+        headers: { Authorization: "Bearer key-1", "X-Admina-Organization-Id": "org-1" },
+      });
+      expect(res.status).toBe(405);
+      expect(res.headers.get("allow")).toBe("POST");
+    });
+
+    it("returns 405 for DELETE /mcp", async () => {
+      const res = await fetch(endpoint(handle), {
+        method: "DELETE",
+        headers: { Authorization: "Bearer key-1", "X-Admina-Organization-Id": "org-1" },
+      });
+      expect(res.status).toBe(405);
+    });
+  });
+
+  describe("body handling", () => {
+    it("returns 400 for invalid JSON body", async () => {
+      const res = await rawPost(
+        endpoint(handle),
+        { Authorization: "Bearer key-1", "X-Admina-Organization-Id": "org-1" },
+        "not-json",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_json");
+    });
+  });
+
+  describe("DNS rebinding protection", () => {
+    it("rejects requests with a disallowed Host header (403)", async () => {
+      const res = await fetch(endpoint(handle), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: "Bearer key-1",
+          "X-Admina-Organization-Id": "org-1",
+          Host: "evil.example.com",
+        },
+        body: "{}",
+      });
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("forbidden_host");
     });
   });
 
@@ -152,9 +258,13 @@ describe("runHttp", () => {
       await transport.close();
     });
 
-    it("isolates credentials across concurrent requests from different tenants", async () => {
+    it("isolates credentials across genuinely concurrent in-flight requests", async () => {
+      // This variant uses a gated axios mock to force all three requests to be
+      // in-flight simultaneously before any returns. Only then can we release
+      // them. If AsyncLocalStorage isolation were broken, the captured axios
+      // call for each tenant would carry the wrong credentials.
       const calls: AxiosCall[] = [];
-      installAxiosCapture(calls, { id: "x" });
+      const gate = installGatedAxios(calls, { id: "x" });
 
       const runTenant = async (apiKey: string, organizationId: string) => {
         const { client, transport } = await makeClient(apiKey, organizationId);
@@ -163,7 +273,20 @@ describe("runHttp", () => {
         await transport.close();
       };
 
-      await Promise.all([runTenant("key-A", "org-A"), runTenant("key-B", "org-B"), runTenant("key-C", "org-C")]);
+      const pending = Promise.all([
+        runTenant("key-A", "org-A"),
+        runTenant("key-B", "org-B"),
+        runTenant("key-C", "org-C"),
+      ]);
+
+      // Wait for all three tool handlers to reach the axios mock — this proves
+      // all three requests are holding live credentials concurrently.
+      await gate.waitUntilInFlight(3);
+      expect(calls).toHaveLength(3);
+
+      // Release and let all requests complete.
+      gate.release();
+      await pending;
 
       const byOrg = (org: string) => calls.find((c) => new RegExp(`/organizations/${org}(/|\\?|$)`).test(c.url));
       expect(byOrg("org-A")?.headers.Authorization).toBe("Bearer key-A");

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,11 +1,20 @@
 import { IncomingMessage, Server as NodeHttpServer, ServerResponse, createServer as createHttpServer } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { Credentials, withCredentials } from "../context.js";
+import { type Credentials, withCredentials } from "../context.js";
 import { createServer } from "../server.js";
 
 export interface HttpOptions {
   port: number;
   host: string;
+  /**
+   * Explicit allow-list of Host header values to accept. When omitted, the
+   * transport auto-populates this with `host:port`, `localhost:port`,
+   * `127.0.0.1:port`, and `[::1]:port` if `host` is a loopback address —
+   * enabling DNS-rebinding protection by default for loopback binds.
+   *
+   * Pass `null` to disable host validation entirely (not recommended).
+   */
+  allowedHosts?: string[] | null;
 }
 
 export interface HttpHandle {
@@ -16,7 +25,12 @@ export interface HttpHandle {
 }
 
 const MCP_PATH = "/mcp";
-const MAX_BODY_BYTES = 1_048_576; // 1 MiB — Admina MCP payloads are small JSON-RPC envelopes.
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB — MCP JSON-RPC envelopes are small.
+
+// Admina organization IDs are numeric in production but we accept any short
+// ASCII-safe identifier to stay forward-compatible. The explicit allow-list
+// prevents path-injection via the URL we interpolate into.
+const ORG_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 
 type AuthSuccess = { ok: true; credentials: Credentials };
 type AuthFailure = { ok: false; status: number; error: string; message: string };
@@ -32,7 +46,9 @@ function extractCredentials(req: IncomingMessage): AuthSuccess | AuthFailure {
     };
   }
 
-  const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  // Allow a single leading/trailing whitespace in the raw header (RFC 7230
+  // permits OWS between field-value and folding), then match the Bearer scheme.
+  const match = /^\s*Bearer\s+(\S.*?)\s*$/i.exec(authHeader);
   if (!match) {
     return {
       ok: false,
@@ -42,19 +58,12 @@ function extractCredentials(req: IncomingMessage): AuthSuccess | AuthFailure {
     };
   }
 
-  const apiKey = match[1].trim();
-  if (!apiKey) {
-    return {
-      ok: false,
-      status: 401,
-      error: "unauthorized",
-      message: "Empty bearer token.",
-    };
-  }
+  const apiKey = match[1];
 
   const orgHeader = req.headers["x-admina-organization-id"];
-  const organizationId = Array.isArray(orgHeader) ? orgHeader[0] : orgHeader;
-  if (!organizationId || !organizationId.trim()) {
+  const organizationIdRaw = Array.isArray(orgHeader) ? orgHeader[0] : orgHeader;
+  const organizationId = organizationIdRaw?.trim() ?? "";
+  if (!organizationId) {
     return {
       ok: false,
       status: 401,
@@ -62,85 +71,145 @@ function extractCredentials(req: IncomingMessage): AuthSuccess | AuthFailure {
       message: "Missing X-Admina-Organization-Id header.",
     };
   }
+  if (!ORG_ID_PATTERN.test(organizationId)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_organization_id",
+      message: "X-Admina-Organization-Id must match /^[A-Za-z0-9_-]{1,64}$/.",
+    };
+  }
 
-  return { ok: true, credentials: { apiKey, organizationId: organizationId.trim() } };
+  return { ok: true, credentials: { apiKey, organizationId } };
+}
+
+function validateHost(req: IncomingMessage, allowedHosts: string[] | null): boolean {
+  if (allowedHosts === null) return true;
+  const host = req.headers.host;
+  if (!host || Array.isArray(host)) return false;
+  return allowedHosts.includes(host.toLowerCase());
+}
+
+function isLoopbackAddress(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === "127.0.0.1" || h === "localhost" || h === "::1" || h === "[::1]";
+}
+
+function resolveAllowedHosts(opts: HttpOptions, boundPort: number): string[] | null {
+  if (opts.allowedHosts === null) return null; // explicit opt-out
+  if (opts.allowedHosts !== undefined) {
+    return opts.allowedHosts.map((h) => h.toLowerCase());
+  }
+  if (!isLoopbackAddress(opts.host)) return null;
+  // Loopback default: allow common loopback representations.
+  return [
+    `${opts.host.toLowerCase()}:${boundPort}`,
+    `localhost:${boundPort}`,
+    `127.0.0.1:${boundPort}`,
+    `[::1]:${boundPort}`,
+  ];
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  if (res.headersSent) return;
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(body));
 }
 
-function readRequestBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
+function readRequestBody(
+  req: IncomingMessage,
+): Promise<{ ok: true; body: string } | { ok: false; reason: "too_large" | "network"; message: string }> {
+  return new Promise((resolve) => {
     let total = 0;
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => {
       total += chunk.length;
       if (total > MAX_BODY_BYTES) {
-        reject(new Error("Request body too large"));
+        resolve({ ok: false, reason: "too_large", message: `Request body exceeds ${MAX_BODY_BYTES} bytes.` });
         req.destroy();
         return;
       }
       chunks.push(chunk);
     });
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", reject);
+    req.on("end", () => resolve({ ok: true, body: Buffer.concat(chunks).toString("utf8") }));
+    req.on("error", (err) => resolve({ ok: false, reason: "network", message: err.message }));
   });
 }
 
-async function handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+async function handleMcpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  allowedHosts: string[] | null,
+): Promise<void> {
+  if (!validateHost(req, allowedHosts)) {
+    sendJson(res, 403, {
+      error: "forbidden_host",
+      message: "Host header is not in the allowed-hosts list.",
+    });
+    return;
+  }
+
+  // Only POST carries an MCP JSON-RPC payload in stateless mode. GET/DELETE
+  // are reserved by the spec for session streams and teardown; we do not
+  // support sessions, so both are meaningless here. 405 with a clear message
+  // is more honest than delegating and hoping the SDK returns the right code.
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    sendJson(res, 405, {
+      error: "method_not_allowed",
+      message: `Method ${req.method} not allowed on ${MCP_PATH}. Only POST is supported (stateless mode).`,
+    });
+    return;
+  }
+
   const auth = extractCredentials(req);
   if (!auth.ok) {
     sendJson(res, auth.status, { error: auth.error, message: auth.message });
     return;
   }
 
+  const bodyResult = await readRequestBody(req);
+  if (!bodyResult.ok) {
+    const status = bodyResult.reason === "too_large" ? 413 : 400;
+    sendJson(res, status, {
+      error: bodyResult.reason === "too_large" ? "payload_too_large" : "bad_request",
+      message: bodyResult.message,
+    });
+    return;
+  }
+
   let parsedBody: unknown;
-  if (req.method === "POST") {
-    let raw: string;
+  if (bodyResult.body.length > 0) {
     try {
-      raw = await readRequestBody(req);
-    } catch (err) {
-      sendJson(res, 413, {
-        error: "payload_too_large",
-        message: err instanceof Error ? err.message : "Failed to read request body",
+      parsedBody = JSON.parse(bodyResult.body);
+    } catch {
+      sendJson(res, 400, {
+        error: "invalid_json",
+        message: "Request body must be valid JSON.",
       });
       return;
     }
-
-    if (raw.length > 0) {
-      try {
-        parsedBody = JSON.parse(raw);
-      } catch {
-        sendJson(res, 400, {
-          error: "invalid_json",
-          message: "Request body must be valid JSON.",
-        });
-        return;
-      }
-    }
   }
 
-  await withCredentials(auth.credentials, async () => {
+  // Freeze a defensive copy so downstream readers cannot mutate the scope.
+  const credentials: Credentials = Object.freeze({ ...auth.credentials });
+
+  await withCredentials(credentials, async () => {
     const server = createServer();
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-
-    res.on("close", () => {
-      transport.close().catch(() => {});
-      server.close().catch(() => {});
-    });
 
     try {
       await server.connect(transport);
       await transport.handleRequest(req, res, parsedBody);
     } catch (err) {
-      if (!res.headersSent) {
-        sendJson(res, 500, {
-          error: "internal_error",
-          message: err instanceof Error ? err.message : "Unexpected transport error",
-        });
-      }
+      sendJson(res, 500, {
+        error: "internal_error",
+        message: err instanceof Error ? err.message : "Unexpected transport error",
+      });
+    } finally {
+      // Idempotent: SDK close() is safe to call multiple times.
+      await transport.close().catch(() => {});
+      await server.close().catch(() => {});
     }
   });
 }
@@ -154,10 +223,17 @@ async function handleMcpRequest(req: IncomingMessage, res: ServerResponse): Prom
  *
  * Transports are constructed per request in stateless mode — a single deployed
  * instance can serve multiple tenants concurrently without cross-request state.
+ *
+ * DNS-rebinding protection: when binding to a loopback interface (the default)
+ * the server requires incoming Host headers to match one of the known loopback
+ * host:port combinations. Pass `allowedHosts: [...]` for a non-loopback bind,
+ * or `allowedHosts: null` to opt out (not recommended).
  */
 export async function runHttp(options: HttpOptions): Promise<HttpHandle> {
+  let finalAllowedHosts: string[] | null = null;
+
   const nodeServer = createHttpServer((req, res) => {
-    const url = new URL(req.url ?? "/", "http://localhost");
+    const url = new URL(req.url ?? "/", "http://placeholder");
 
     if (url.pathname !== MCP_PATH) {
       sendJson(res, 404, {
@@ -167,13 +243,11 @@ export async function runHttp(options: HttpOptions): Promise<HttpHandle> {
       return;
     }
 
-    handleMcpRequest(req, res).catch((err) => {
-      if (!res.headersSent) {
-        sendJson(res, 500, {
-          error: "internal_error",
-          message: err instanceof Error ? err.message : "Unexpected error",
-        });
-      }
+    handleMcpRequest(req, res, finalAllowedHosts).catch((err) => {
+      sendJson(res, 500, {
+        error: "internal_error",
+        message: err instanceof Error ? err.message : "Unexpected error",
+      });
     });
   });
 
@@ -187,6 +261,7 @@ export async function runHttp(options: HttpOptions): Promise<HttpHandle> {
 
   const address = nodeServer.address();
   const boundPort = typeof address === "object" && address ? address.port : options.port;
+  finalAllowedHosts = resolveAllowedHosts(options, boundPort);
 
   return {
     server: nodeServer,

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,0 +1,200 @@
+import { IncomingMessage, Server as NodeHttpServer, ServerResponse, createServer as createHttpServer } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { Credentials, withCredentials } from "../context.js";
+import { createServer } from "../server.js";
+
+export interface HttpOptions {
+  port: number;
+  host: string;
+}
+
+export interface HttpHandle {
+  server: NodeHttpServer;
+  port: number;
+  host: string;
+  close: () => Promise<void>;
+}
+
+const MCP_PATH = "/mcp";
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB — Admina MCP payloads are small JSON-RPC envelopes.
+
+type AuthSuccess = { ok: true; credentials: Credentials };
+type AuthFailure = { ok: false; status: number; error: string; message: string };
+
+function extractCredentials(req: IncomingMessage): AuthSuccess | AuthFailure {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || Array.isArray(authHeader)) {
+    return {
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message: "Missing Authorization header. Expected: 'Authorization: Bearer <ADMINA_API_KEY>'.",
+    };
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  if (!match) {
+    return {
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message: "Invalid Authorization header. Expected: 'Authorization: Bearer <ADMINA_API_KEY>'.",
+    };
+  }
+
+  const apiKey = match[1].trim();
+  if (!apiKey) {
+    return {
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message: "Empty bearer token.",
+    };
+  }
+
+  const orgHeader = req.headers["x-admina-organization-id"];
+  const organizationId = Array.isArray(orgHeader) ? orgHeader[0] : orgHeader;
+  if (!organizationId || !organizationId.trim()) {
+    return {
+      ok: false,
+      status: 401,
+      error: "unauthorized",
+      message: "Missing X-Admina-Organization-Id header.",
+    };
+  }
+
+  return { ok: true, credentials: { apiKey, organizationId: organizationId.trim() } };
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let total = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_BODY_BYTES) {
+        reject(new Error("Request body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+async function handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const auth = extractCredentials(req);
+  if (!auth.ok) {
+    sendJson(res, auth.status, { error: auth.error, message: auth.message });
+    return;
+  }
+
+  let parsedBody: unknown;
+  if (req.method === "POST") {
+    let raw: string;
+    try {
+      raw = await readRequestBody(req);
+    } catch (err) {
+      sendJson(res, 413, {
+        error: "payload_too_large",
+        message: err instanceof Error ? err.message : "Failed to read request body",
+      });
+      return;
+    }
+
+    if (raw.length > 0) {
+      try {
+        parsedBody = JSON.parse(raw);
+      } catch {
+        sendJson(res, 400, {
+          error: "invalid_json",
+          message: "Request body must be valid JSON.",
+        });
+        return;
+      }
+    }
+  }
+
+  await withCredentials(auth.credentials, async () => {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+
+    res.on("close", () => {
+      transport.close().catch(() => {});
+      server.close().catch(() => {});
+    });
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    } catch (err) {
+      if (!res.headersSent) {
+        sendJson(res, 500, {
+          error: "internal_error",
+          message: err instanceof Error ? err.message : "Unexpected transport error",
+        });
+      }
+    }
+  });
+}
+
+/**
+ * Starts an HTTP server that accepts Streamable HTTP MCP requests at `/mcp`.
+ *
+ * Every request carries its own Admina credentials via headers:
+ *   - Authorization: Bearer <ADMINA_API_KEY>
+ *   - X-Admina-Organization-Id: <ADMINA_ORGANIZATION_ID>
+ *
+ * Transports are constructed per request in stateless mode — a single deployed
+ * instance can serve multiple tenants concurrently without cross-request state.
+ */
+export async function runHttp(options: HttpOptions): Promise<HttpHandle> {
+  const nodeServer = createHttpServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+
+    if (url.pathname !== MCP_PATH) {
+      sendJson(res, 404, {
+        error: "not_found",
+        message: `Unknown path: ${url.pathname}. Only ${MCP_PATH} is supported.`,
+      });
+      return;
+    }
+
+    handleMcpRequest(req, res).catch((err) => {
+      if (!res.headersSent) {
+        sendJson(res, 500, {
+          error: "internal_error",
+          message: err instanceof Error ? err.message : "Unexpected error",
+        });
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    nodeServer.once("error", reject);
+    nodeServer.listen(options.port, options.host, () => {
+      nodeServer.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = nodeServer.address();
+  const boundPort = typeof address === "object" && address ? address.port : options.port;
+
+  return {
+    server: nodeServer,
+    port: boundPort,
+    host: options.host,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        nodeServer.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,0 +1,15 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createServer } from "../server.js";
+
+/**
+ * Runs the MCP server over stdio.
+ *
+ * Credentials are read from `ADMINA_API_KEY` and `ADMINA_ORGANIZATION_ID`
+ * environment variables on first tool invocation (see `getClient()` in
+ * `admina-api.ts`).
+ */
+export async function runStdio(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}


### PR DESCRIPTION
## Summary

Adds a Streamable HTTP transport alongside the existing stdio MCP transport so a single `admina-mcp-server` instance can serve multiple Admina organizations remotely over HTTP.

- Stateless Streamable HTTP (`@modelcontextprotocol/sdk` 1.26 `StreamableHTTPServerTransport`) — no session state, one `Server`+`Transport` per request.
- Per-request credentials via headers: `Authorization: Bearer <ADMINA_API_KEY>` + `X-Admina-Organization-Id: <ORG_ID>`.
- AsyncLocalStorage-backed credential scope — 30+ tool handlers continue to call `getClient()` unchanged; the HTTP transport binds credentials to the async context per request.
- Backward-compatible stdio mode preserved (env-var path unchanged).
- Security hardening: DNS-rebinding protection on by default for loopback binds; org-ID shape validation; body size cap (1 MiB); per-request freezing of the credential scope.

## Ticket
- Notion: [ADM-763 · Remote MCP server](https://www.notion.so/mfi/Remote-MCP-server-33a9b9c183cb8069aa4cd5e1b8c6545b)
- PDD: [discussion #36 · Remote MCP / Public API](https://github.com/moneyforward-i/admina-product-document/discussions/36)

## Plan
[`docs/plans/2026-04-23-adm-763-remote-mcp-server.md`](docs/plans/2026-04-23-adm-763-remote-mcp-server.md) — design decisions, acceptance criteria, phased implementation, risk table.

## Design choices

| Decision | Rationale |
|---|---|
| Stateless HTTP (no session) | Horizontal scalability; natural fit for multi-tenant per-request credentials |
| Bearer token + `X-Admina-Organization-Id` headers | Matches Admina's existing REST API auth; OAuth 2.1 deferrable to a later ticket |
| AsyncLocalStorage credential scope | Avoids threading credentials through every tool signature; isolates concurrent requests |
| Fresh `Server` + `Transport` per request | Zero shared state between tenants; SDK's stateless mode expects this pattern |
| Node `http` module, no new HTTP framework | Single POST endpoint; `express` pulls in weight we don't need |
| Loopback bind by default | Public exposure is explicit opt-in via `--host 0.0.0.0` |

## CLI

```
admina-mcp-server                               # stdio (unchanged default)
admina-mcp-server --http --port 3000 --host 127.0.0.1
MCP_TRANSPORT=http MCP_HTTP_PORT=3000 admina-mcp-server
```

## Review

5-lane cross-model review dispatched. Two lanes completed cleanly:
- **Opus 4.7** — initial verdict `CHANGES_NEEDED`; all three blockers (DNS rebinding, vacuous isolation test, double-close race) addressed in the second commit.
- **Opus 4.6** — verdict `SHIP`; minors from Opus 4.6 (typo, type-only imports, missing 400/405 test cases) also addressed.
- Three GPT lanes (5.2, 5.3-codex, 5.4-high via `codex-plugin-cc`) errored on model access; the Opus lanes alone produced convergent findings which have all been addressed.

## Tests

- `yarn lint` — clean
- `yarn build` — clean
- `yarn test` — 159 / 159 passing
- Manual smoke test of the compiled binary in HTTP mode — 401 / 403 / 404 / 405 paths all return the expected bodies

## Test plan
- [ ] Reviewer: inspect the AsyncLocalStorage plumbing in `src/context.ts` + `src/admina-api.ts` and the per-request server in `src/transports/http.ts`
- [ ] Reviewer: skim `docs/remote-mcp.md` for the operator-facing contract (headers, DNS rebinding, error taxonomy)
- [ ] Reviewer: confirm the stdio path (`src/transports/stdio.ts`) still matches the existing install-via-npx behavior
- [ ] Run `yarn lint && yarn build && yarn test` locally
- [ ] Smoke test the HTTP mode against a sandbox Admina API key:
  ```
  admina-mcp-server --http --port 3000
  curl -X POST http://127.0.0.1:3000/mcp \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -H "Authorization: Bearer $ADMINA_API_KEY" \
    -H "X-Admina-Organization-Id: $ADMINA_ORGANIZATION_ID" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
  ```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moneyforward-i/admina-mcp-server/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
